### PR TITLE
Fixed Nicosia ambiguity - made it "North Nicosia"

### DIFF
--- a/Ultimate_Geography/Ultimate_Geography.json
+++ b/Ultimate_Geography/Ultimate_Geography.json
@@ -5734,7 +5734,7 @@
             "fields": [
                 "Northern Cyprus", 
                 "State recognised only by Turkey and claimed by Cyprus.", 
-                "Nicosia", 
+                "North Nicosia", 
                 "", 
                 "", 
                 "<img src=\"ug-flag-northern_cyprus.svg\" />", 


### PR DESCRIPTION
While playing I got a card with Nicosia in the front which I thought was the Cyprus capital. It turned out to be the *Northern* Cyprus capital which surprised me so I checked it on the internet.

The truth is, Nicosia is capital of both states and is divided by a UN-controlled buffer zone ([wiki](https://en.wikipedia.org/wiki/Northern_Cyprus), and other sources claim this, too)

To avoid ambiguity I renamed Nicosia of the Northern Cyprus to *North Nicosia*, as it's done in wikipedia: https://en.wikipedia.org/wiki/North_Nicosia