### PR TITLE
Prepare German deck by duplicating English deck

### DIFF
--- a/Ultimate_Geography_(DE)/Ultimate_Geography_(DE).json
+++ b/Ultimate_Geography_(DE)/Ultimate_Geography_(DE).json
@@ -1,0 +1,7499 @@
+{
+    "__type__": "Deck", 
+    "children": [], 
+    "crowdanki_uuid": "23ac55d1-32bb-11e8-a15b-a0481cc15658", 
+    "deck_config_uuid": "924484df-cc9b-11e6-ab16-a0481cc15658", 
+    "deck_configurations": [
+        {
+            "__type__": "DeckConfig", 
+            "autoplay": false, 
+            "crowdanki_uuid": "924484df-cc9b-11e6-ab16-a0481cc15658", 
+            "dyn": false, 
+            "lapse": {
+                "delays": [
+                    10
+                ], 
+                "leechAction": 0, 
+                "leechFails": 8, 
+                "minInt": 1, 
+                "mult": 0.0
+            }, 
+            "maxTaken": 60, 
+            "name": "Default", 
+            "new": {
+                "bury": true, 
+                "delays": [
+                    1, 
+                    10
+                ], 
+                "initialFactor": 2500, 
+                "ints": [
+                    1, 
+                    4, 
+                    7
+                ], 
+                "order": 0, 
+                "perDay": 15, 
+                "separate": true
+            }, 
+            "replayq": true, 
+            "rev": {
+                "bury": true, 
+                "ease4": 1.3, 
+                "fuzz": 0.05, 
+                "ivlFct": 1.0, 
+                "maxIvl": 36500, 
+                "minSpace": 1, 
+                "perDay": 100
+            }, 
+            "timer": 0
+        }
+    ], 
+    "desc": "<b>FULL DESCRIPTION:</b> <a href=\"https://github.com/axelboc/anki-ultimate-geography/\">https://github.com/axelboc/anki-ultimate-geography/</a>\n<b>RELEASE NOTES:</b> <a href=\"https://github.com/axelboc/anki-ultimate-geography/releases\">https://github.com/axelboc/anki-ultimate-geography/releases</a>\n\n<b>Ultimate Geography</b> features:\n\n- the world's <a href=\"https://en.wikipedia.org/wiki/List_of_sovereign_states\"><b>206 sovereign states</b></a> (824 cards)\n- <b>67 overseas territories</b>, dependent areas, and more (227 cards)\n- <b>39 oceans and seas</b>, and <b>7 continents</b> (46 cards, maps only)\n- for a total of <b>319 unique notes</b>, <b>1097 cards</b>, <b>260 flags</b>, and <b>317 maps</b>.\n\nThe flags and most of the maps are sourced from <a href=\"https://commons.wikimedia.org/\">Wikimedia Commons</a>, provided as SVG or PNG, and optimised for smaller file size. Some cards include extra information such as: similar flags, governance information, alternative country names, etc.\n\nThis deck is maintained with the <a href=\"https://ankiweb.net/shared/info/1788670778\">CrowdAnki</a> add-on and <a href=\"https://github.com/axelboc/anki-ultimate-geography\">available on GitHub</a>. If you spot a mistake, have a suggestion or want to help, please don't hesitate to <a href=\"https://github.com/axelboc/anki-ultimate-geography/issues\">raise an issue</a>. If you wish to <b>stay informed of new releases</b>, watch the GitHub repository or subscribe to the <a href=\"https://github.com/axelboc/anki-ultimate-geography/releases.atom\">releases feed</a> on GitHub.\n\nThis deck is built on top of an existing <a href=\"https://ankiweb.net/shared/info/261823898\">shared deck</a>. My initial goal was to resolve some of the issues mentioned in the comments such as the poor quality of the flags, but I ended up doing <i>a lot</i> more, including putting the deck up on GitHub, rethinking the tags, and reviewing all of the content. For a full list of changes, check out the <a href=\"https://github.com/axelboc/anki-ultimate-geography/releases/tag/v2.0\">initial release notes</a>.", 
+    "dyn": 0, 
+    "extendNew": 10, 
+    "extendRev": 50, 
+    "media_files": [
+        "ug-map-sweden.png", 
+        "ug-map-england.png", 
+        "ug-map-algeria.png", 
+        "ug-map-malaysia.png", 
+        "ug-flag-guam.svg", 
+        "ug-map-benin.png", 
+        "ug-map-gulf_of_carpenteria.jpg", 
+        "ug-flag-australia.svg", 
+        "ug-flag-kyrgyzstan.svg", 
+        "ug-map-tokelau.png", 
+        "ug-map-uzbekistan.png", 
+        "ug-flag-jordan.svg", 
+        "ug-map-paraguay.png", 
+        "ug-flag-rwanda.svg", 
+        "ug-flag-liberia.svg", 
+        "ug-map-niger.png", 
+        "ug-map-cape_verde.png", 
+        "ug-flag-dominica.svg", 
+        "ug-map-asia.png", 
+        "ug-flag-nigeria.svg", 
+        "ug-map-uruguay.png", 
+        "ug-flag-gibraltar.svg", 
+        "ug-map-turkmenistan.png", 
+        "ug-map-federated_states_of_micronesia.png", 
+        "ug-flag-cape_verde.svg", 
+        "ug-flag-chad.svg", 
+        "ug-map-palau.png", 
+        "ug-map-norfolk_island.png", 
+        "ug-flag-swaziland.svg", 
+        "ug-flag-egypt.svg", 
+        "ug-map-poland.png", 
+        "ug-flag-ireland.svg", 
+        "ug-map-united_kingdom.png", 
+        "ug-map-italy.png", 
+        "ug-map-coral_sea.jpg", 
+        "ug-flag-switzerland.svg", 
+        "ug-map-belgium.png", 
+        "ug-map-ethiopia.png", 
+        "ug-map-syria.png", 
+        "ug-map-sri_lanka.png", 
+        "ug-flag-tajikistan.svg", 
+        "ug-map-luxembourg.png", 
+        "ug-flag-cayman_islands.svg", 
+        "ug-map-nigeria.png", 
+        "ug-flag-croatia.png", 
+        "ug-map-comoros.png", 
+        "ug-flag-french_polynesia.svg", 
+        "ug-flag-wales.svg", 
+        "ug-flag-united_states_of_america.svg", 
+        "ug-flag-macedonia.svg", 
+        "ug-flag-canada.svg", 
+        "ug-map-armenia.png", 
+        "ug-flag-indonesia.svg", 
+        "ug-map-malta.png", 
+        "ug-flag-brunei.svg", 
+        "ug-map-argentina.png", 
+        "ug-flag-marshall_islands.svg", 
+        "ug-flag-federated_states_of_micronesia.svg", 
+        "ug-map-cyprus.png", 
+        "ug-map-senegal.png", 
+        "ug-map-sea_of_galilee.jpg", 
+        "ug-flag-tuvalu.svg", 
+        "ug-map-estonia.png", 
+        "ug-flag-saint_kitts_and_nevis.svg", 
+        "ug-map-martinique.png", 
+        "ug-map-nepal.png", 
+        "ug-flag-papua_new_guinea.svg", 
+        "ug-map-albania.png", 
+        "ug-flag-ghana.svg", 
+        "ug-flag-republic_of_the_congo.svg", 
+        "ug-flag-philippines.svg", 
+        "ug-flag-mali.svg", 
+        "ug-flag-england.svg", 
+        "ug-flag-qatar.svg", 
+        "ug-map-chad.png", 
+        "ug-flag-antigua_and_barbuda.svg", 
+        "ug-map-croatia.png", 
+        "ug-map-tajikistan.png", 
+        "ug-flag-iran.svg", 
+        "ug-map-aral_sea.jpg", 
+        "ug-map-norwegian_sea.jpg", 
+        "ug-map-isle_of_man.png", 
+        "ug-map-laos.png", 
+        "ug-map-arctic_ocean.jpg", 
+        "ug-map-south_korea.png", 
+        "ug-map-northern_cyprus.png", 
+        "ug-map-new_zealand.png", 
+        "ug-map-vatican_city.png", 
+        "ug-flag-european_union.svg", 
+        "ug-map-oceania.png", 
+        "ug-map-swaziland.png", 
+        "ug-flag-singapore.svg", 
+        "ug-map-madagascar.png", 
+        "ug-flag-aland_islands.svg", 
+        "ug-flag-belarus.svg", 
+        "ug-map-scotland.png", 
+        "ug-map-switzerland.png", 
+        "ug-map-serbia.png", 
+        "ug-flag-new_caledonia.svg", 
+        "ug-map-uganda.png", 
+        "ug-map-myanmar.png", 
+        "ug-map-togo.png", 
+        "ug-map-philippine_sea.jpg", 
+        "ug-map-cuba.png", 
+        "ug-map-aruba.png", 
+        "ug-map-faroe_islands.png", 
+        "ug-map-egypt.png", 
+        "ug-flag-british_virgin_islands.svg", 
+        "ug-map-vietnam.png", 
+        "ug-map-pakistan.png", 
+        "ug-map-hungary.png", 
+        "ug-map-reunion.png", 
+        "ug-flag-bolivia.png", 
+        "ug-flag-isle_of_man.svg", 
+        "ug-flag-senegal.svg", 
+        "ug-map-africa.png", 
+        "ug-flag-brazil.svg", 
+        "ug-flag-tanzania.svg", 
+        "ug-map-the_bahamas.png", 
+        "ug-map-guyana.png", 
+        "ug-map-gulf_of_mexico.jpg", 
+        "ug-map-labrador_sea.jpg", 
+        "ug-map-dead_sea.jpg", 
+        "ug-flag-sri_lanka.svg", 
+        "ug-map-panama.png", 
+        "ug-flag-bulgaria.svg", 
+        "ug-flag-sweden.svg", 
+        "ug-map-bhutan.png", 
+        "ug-map-antarctica.png", 
+        "ug-map-liechtenstein.png", 
+        "ug-map-ghana.png", 
+        "ug-flag-slovakia.svg", 
+        "ug-map-slovenia.png", 
+        "ug-map-cayman_islands.png", 
+        "ug-map-tanzania.png", 
+        "ug-map-kuwait.png", 
+        "ug-map-greece.png", 
+        "ug-map-montenegro.png", 
+        "ug-flag-barbados.svg", 
+        "ug-flag-hungary.svg", 
+        "ug-flag-maldives.svg", 
+        "ug-flag-honduras.svg", 
+        "ug-flag-mauritania.svg", 
+        "ug-map-canary_islands.png", 
+        "ug-map-colombia.png", 
+        "ug-map-kiribati.png", 
+        "ug-flag-falkland_islands.svg", 
+        "ug-flag-djibouti.svg", 
+        "ug-map-solomon_islands.png", 
+        "ug-flag-peru.svg", 
+        "ug-flag-poland.svg", 
+        "ug-map-scandinavia.jpg", 
+        "ug-map-democratic_republic_of_the_congo.png", 
+        "ug-map-central_african_republic.png", 
+        "ug-flag-comoros.svg", 
+        "ug-map-pitcairn_islands.png", 
+        "ug-map-java.png", 
+        "ug-flag-portugal.svg", 
+        "ug-map-falkland_islands.png", 
+        "ug-map-germany.png", 
+        "ug-flag-botswana.svg", 
+        "ug-map-marshall_islands.png", 
+        "ug-flag-sardinia.svg", 
+        "ug-map-namibia.png", 
+        "ug-map-europe.png", 
+        "ug-map-portugal.png", 
+        "ug-flag-ethiopia.svg", 
+        "ug-map-singapore.png", 
+        "ug-flag-argentina.svg", 
+        "ug-flag-gabon.svg", 
+        "ug-flag-south_ossetia.svg", 
+        "ug-map-mauritius.png", 
+        "ug-map-wales.png", 
+        "ug-flag-georgia.svg", 
+        "ug-map-new_caledonia.png", 
+        "ug-map-taiwan.png", 
+        "ug-flag-tunisia.svg", 
+        "ug-flag-norway.svg", 
+        "ug-map-white_sea.jpg", 
+        "ug-map-sardinia.jpg", 
+        "ug-map-abkhazia.png", 
+        "ug-map-maldives.png", 
+        "ug-map-thailand.png", 
+        "ug-flag-sudan.svg", 
+        "ug-map-guadeloupe.png", 
+        "ug-flag-yemen.svg", 
+        "ug-flag-northern_cyprus.svg", 
+        "ug-flag-bermuda.svg", 
+        "ug-flag-sierra_leone.svg", 
+        "ug-map-saba.png", 
+        "ug-map-south_ossetia.png", 
+        "ug-map-curacao.png", 
+        "ug-flag-chile.svg", 
+        "ug-map-yemen.png", 
+        "ug-flag-puerto_rico.svg", 
+        "ug-flag-seychelles.svg", 
+        "ug-map-british_indian_ocean_territory.png", 
+        "ug-map-turks_and_caicos_islands.png", 
+        "ug-flag-saba.svg", 
+        "ug-map-monaco.png", 
+        "ug-map-micronesia.jpg", 
+        "ug-flag-ecuador.png", 
+        "ug-flag-montserrat.svg", 
+        "ug-flag-equatorial_guinea.svg", 
+        "ug-map-montserrat.png", 
+        "ug-map-artsakh.png", 
+        "ug-map-slovakia.png", 
+        "ug-map-zambia.png", 
+        "ug-flag-south_korea.svg", 
+        "ug-flag-transnistria.svg", 
+        "ug-flag-anguilla.svg", 
+        "ug-flag-niue.svg", 
+        "ug-map-bonaire.png", 
+        "ug-flag-saint_lucia.svg", 
+        "ug-map-bering_strait.jpg", 
+        "ug-flag-malawi.svg", 
+        "ug-map-jersey.png", 
+        "ug-flag-the_gambia.svg", 
+        "ug-flag-czech_republic.svg", 
+        "ug-flag-bonaire.svg", 
+        "ug-map-mayotte.png", 
+        "ug-map-iceland.png", 
+        "ug-map-romania.png", 
+        "ug-flag-bosnia_and_herzegovina.svg", 
+        "ug-map-dominica.png", 
+        "ug-flag-haiti.svg", 
+        "ug-map-anguilla.png", 
+        "ug-map-france.png", 
+        "ug-flag-morocco.svg", 
+        "ug-map-nauru.png", 
+        "ug-flag-sint_eustatius.svg", 
+        "ug-flag-tokelau.svg", 
+        "ug-map-kazakhstan.png", 
+        "ug-map-easter_island.png", 
+        "ug-map-hong_kong.png", 
+        "ug-flag-kenya.svg", 
+        "ug-flag-easter_island.svg", 
+        "ug-flag-belize.png", 
+        "ug-map-south_china_sea.jpg", 
+        "ug-flag-ivory_coast.svg", 
+        "ug-flag-south_africa.svg", 
+        "ug-flag-vatican_city.svg", 
+        "ug-map-saint_helena.jpg", 
+        "ug-flag-cameroon.svg", 
+        "ug-flag-luxembourg.svg", 
+        "ug-flag-el_salvador.png", 
+        "ug-flag-ukraine.svg", 
+        "ug-map-english_channel.jpg", 
+        "ug-flag-italy.svg", 
+        "ug-map-corsica.jpg", 
+        "ug-map-equatorial_guinea.png", 
+        "ug-map-india.png", 
+        "ug-map-belize.png", 
+        "ug-map-sea_of_japan.jpg", 
+        "ug-map-ecuador.png", 
+        "ug-map-gulf_of_california.jpg", 
+        "ug-map-libya.png", 
+        "ug-map-angola.png", 
+        "ug-flag-uzbekistan.svg", 
+        "ug-flag-madeira.svg", 
+        "ug-map-qatar.png", 
+        "ug-flag-spain.png", 
+        "ug-map-andorra.png", 
+        "ug-flag-india.svg", 
+        "ug-map-belarus.png", 
+        "ug-flag-saint_helena.png", 
+        "ug-map-puerto_rico.png", 
+        "ug-map-persian_gulf.jpg", 
+        "ug-flag-democratic_republic_of_the_congo.svg", 
+        "ug-flag-afghanistan.png", 
+        "ug-flag-canary_islands.svg", 
+        "ug-map-sint_maarten.png", 
+        "ug-flag-nepal.svg", 
+        "ug-flag-china.svg", 
+        "ug-map-lesotho.png", 
+        "ug-flag-galapagos_islands.svg", 
+        "ug-flag-jersey.svg", 
+        "ug-flag-united_states_virgin_islands.svg", 
+        "ug-map-gulf_of_thailand.jpg", 
+        "ug-map-philippines.png", 
+        "ug-flag-moldova.svg", 
+        "ug-map-burkina_faso.png", 
+        "ug-flag-panama.svg", 
+        "ug-map-transnistria.png", 
+        "ug-flag-greece.svg", 
+        "ug-map-macedonia.png", 
+        "ug-map-kenya.png", 
+        "ug-map-sao_tome_and_principe.png", 
+        "ug-flag-burundi.svg", 
+        "ug-flag-samoa.svg", 
+        "ug-map-ceuta.jpg", 
+        "ug-flag-uganda.svg", 
+        "ug-map-georgia.png", 
+        "ug-flag-costa_rica.svg", 
+        "ug-flag-cuba.svg", 
+        "ug-map-japan.png", 
+        "ug-flag-belgium.svg", 
+        "ug-flag-mozambique.svg", 
+        "ug-flag-vanuatu.svg", 
+        "ug-flag-abkhazia.svg", 
+        "ug-map-mediterranean_sea.jpg", 
+        "ug-flag-bali.png", 
+        "ug-map-guernsey.png", 
+        "ug-map-afghanistan.png", 
+        "ug-flag-jamaica.svg", 
+        "ug-map-bahrain.png", 
+        "ug-flag-nicaragua.svg", 
+        "ug-flag-guyana.svg", 
+        "ug-map-north_america.png", 
+        "ug-map-northern_mariana_islands.png", 
+        "ug-map-venezuela.png", 
+        "ug-flag-armenia.svg", 
+        "ug-map-united_arab_emirates.png", 
+        "ug-flag-niger.svg", 
+        "ug-flag-vietnam.svg", 
+        "ug-map-guatemala.png", 
+        "ug-flag-ceuta.png", 
+        "ug-map-tuvalu.png", 
+        "ug-flag-saint_vincent_and_the_grenadines.svg", 
+        "ug-flag-sint_maarten.svg", 
+        "ug-map-the_gambia.png", 
+        "ug-flag-angola.svg", 
+        "ug-flag-turkmenistan.svg", 
+        "ug-flag-finland.svg", 
+        "ug-flag-faroe_islands.svg", 
+        "ug-flag-malaysia.svg", 
+        "ug-map-lithuania.png", 
+        "ug-map-cocos_islands.png", 
+        "ug-map-baltic_sea.jpg", 
+        "ug-map-saudi_arabia.png", 
+        "ug-flag-mount_athos.png", 
+        "ug-map-hudson_bay.jpg", 
+        "ug-flag-melilla.png", 
+        "ug-map-netherlands.png", 
+        "ug-map-madeira.png", 
+        "ug-flag-benin.svg", 
+        "ug-map-costa_rica.png", 
+        "ug-map-sumatra.jpg", 
+        "ug-map-north_korea.png", 
+        "ug-map-jamaica.png", 
+        "ug-flag-aruba.svg", 
+        "ug-map-arabian_sea.jpg", 
+        "ug-flag-algeria.svg", 
+        "ug-map-barbados.png", 
+        "ug-flag-scotland.svg", 
+        "ug-flag-norfolk_island.svg", 
+        "ug-map-sahrawi_republic.png", 
+        "ug-flag-east_timor.svg", 
+        "ug-flag-curacao.svg", 
+        "ug-map-botswana.png", 
+        "ug-flag-dominican_republic.png", 
+        "ug-flag-thailand.svg", 
+        "ug-map-ivory_coast.png", 
+        "ug-map-peru.png", 
+        "ug-map-fiji.png", 
+        "ug-flag-corsica.svg", 
+        "ug-flag-malta.svg", 
+        "ug-flag-cook_islands.svg", 
+        "ug-flag-bahrain.svg", 
+        "ug-map-french_guiana.png", 
+        "ug-map-french_polynesia.png", 
+        "ug-map-balkan_peninsula.png", 
+        "ug-map-mongolia.png", 
+        "ug-map-moldova.png", 
+        "ug-map-kosovo.png", 
+        "ug-map-greenland.png", 
+        "ug-map-british_virgin_islands.png", 
+        "ug-map-guinea-bissau.png", 
+        "ug-map-adriatic_sea.jpg", 
+        "ug-flag-madagascar.svg", 
+        "ug-map-european_union.png", 
+        "ug-map-mali.png", 
+        "ug-map-kaliningrad_oblast.jpg", 
+        "ug-flag-oman.svg", 
+        "ug-flag-fiji.png", 
+        "ug-map-sint_eustatius.png", 
+        "ug-map-liberia.png", 
+        "ug-flag-denmark.svg", 
+        "ug-map-black_sea.jpg", 
+        "ug-map-seychelles.png", 
+        "ug-flag-iceland.svg", 
+        "ug-flag-burkina_faso.svg", 
+        "ug-flag-united_arab_emirates.svg", 
+        "ug-map-yellow_sea.jpg", 
+        "ug-map-somaliland.png", 
+        "ug-map-sierra_leone.png", 
+        "ug-flag-andorra.png", 
+        "ug-map-ireland.png", 
+        "ug-map-trinidad_and_tobago.png", 
+        "ug-flag-libya.svg", 
+        "ug-map-south_sudan.png", 
+        "ug-flag-british_indian_ocean_territory.svg", 
+        "ug-map-bermuda.png", 
+        "ug-flag-central_african_republic.svg", 
+        "ug-map-brunei.png", 
+        "ug-flag-bangladesh.svg", 
+        "ug-map-mozambique.png", 
+        "ug-map-kyrgyzstan.png", 
+        "ug-flag-sahrawi_republic.svg", 
+        "ug-map-vanuatu.png", 
+        "ug-flag-south_sudan.svg", 
+        "ug-flag-kaliningrad_oblast.svg", 
+        "ug-flag-new_zealand.svg", 
+        "ug-flag-azerbaijan.svg", 
+        "ug-flag-kosovo.svg", 
+        "ug-flag-mexico.png", 
+        "ug-map-eritrea.png", 
+        "ug-flag-liechtenstein.svg", 
+        "ug-flag-iraq.svg", 
+        "ug-map-indian_ocean.jpg", 
+        "ug-flag-guernsey.svg", 
+        "ug-map-san_marino.png", 
+        "ug-flag-romania.svg", 
+        "ug-flag-montenegro.png", 
+        "ug-map-chile.png", 
+        "ug-map-caspian_sea.jpg", 
+        "ug-map-gibraltar.png", 
+        "ug-flag-macau.svg", 
+        "ug-flag-american_samoa.png", 
+        "ug-flag-japan.svg", 
+        "ug-map-aegean_sea.jpg", 
+        "ug-map-mauritania.png", 
+        "ug-flag-taiwan.svg", 
+        "ug-flag-mongolia.svg", 
+        "ug-flag-sao_tome_and_principe.svg", 
+        "ug-map-norway.png", 
+        "ug-flag-cambodia.svg", 
+        "ug-flag-pakistan.svg", 
+        "ug-map-dominican_republic.png", 
+        "ug-map-bay_of_biscay.jpg", 
+        "ug-flag-austria.svg", 
+        "ug-map-south_america.png", 
+        "ug-flag-palestine.svg", 
+        "ug-map-lebanon.png", 
+        "ug-map-oman.png", 
+        "ug-flag-pitcairn_islands.svg", 
+        "ug-map-haiti.png", 
+        "ug-flag-san_marino.png", 
+        "ug-map-spain.png", 
+        "ug-map-melilla.jpg", 
+        "ug-map-american_samoa.png", 
+        "ug-map-palestine.png", 
+        "ug-map-el_salvador.png", 
+        "ug-map-burundi.png", 
+        "ug-map-cook_islands.png", 
+        "ug-flag-kuwait.svg", 
+        "ug-flag-zimbabwe.svg", 
+        "ug-flag-slovenia.svg", 
+        "ug-map-pacific_ocean.jpg", 
+        "ug-flag-lebanon.svg", 
+        "ug-flag-northern_mariana_islands.svg", 
+        "ug-flag-russia.svg", 
+        "ug-map-united_states_of_america.png", 
+        "ug-map-southern_ocean.jpg", 
+        "ug-map-aland_islands.png", 
+        "ug-flag-estonia.svg", 
+        "ug-map-cameroon.png", 
+        "ug-flag-lesotho.svg", 
+        "ug-map-bay_of_bengal.jpg", 
+        "ug-map-israel.png", 
+        "ug-flag-namibia.svg", 
+        "ug-map-malawi.png", 
+        "ug-flag-somaliland.svg", 
+        "ug-map-latvia.png", 
+        "ug-map-saint_lucia.png", 
+        "ug-flag-eritrea.svg", 
+        "ug-flag-tonga.svg", 
+        "ug-map-indonesia.png", 
+        "ug-flag-solomon_islands.svg", 
+        "ug-flag-monaco.svg", 
+        "ug-map-jordan.png", 
+        "ug-flag-venezuela.svg", 
+        "ug-map-bangladesh.png", 
+        "ug-map-iraq.png", 
+        "ug-flag-trinidad_and_tobago.svg", 
+        "ug-map-china.png", 
+        "ug-map-saint_vincent_and_the_grenadines.png", 
+        "ug-map-bosnia_and_herzegovina.png", 
+        "ug-map-czech_republic.png", 
+        "ug-flag-suriname.svg", 
+        "ug-map-celtic_sea.jpg", 
+        "ug-map-united_states_virgin_islands.png", 
+        "ug-flag-the_bahamas.svg", 
+        "ug-flag-guinea.svg", 
+        "ug-flag-greenland.svg", 
+        "ug-map-canada.png", 
+        "ug-map-republic_of_the_congo.png", 
+        "ug-flag-serbia.png", 
+        "ug-map-denmark_strait.jpg", 
+        "ug-map-brazil.png", 
+        "ug-flag-laos.svg", 
+        "ug-map-nicaragua.png", 
+        "ug-flag-azores.svg", 
+        "ug-flag-kazakhstan.svg", 
+        "ug-flag-palau.svg", 
+        "ug-map-christmas_island.png", 
+        "ug-map-cambodia.png", 
+        "ug-map-zimbabwe.png", 
+        "ug-map-honduras.png", 
+        "ug-flag-hong_kong.svg", 
+        "ug-map-tonga.png", 
+        "ug-map-somalia.png", 
+        "ug-map-sudan.png", 
+        "ug-map-azerbaijan.png", 
+        "ug-flag-sicily.svg", 
+        "ug-map-djibouti.png", 
+        "ug-flag-myanmar.svg", 
+        "ug-map-niue.png", 
+        "ug-map-tunisia.png", 
+        "ug-flag-turks_and_caicos_islands.svg", 
+        "ug-flag-lithuania.svg", 
+        "ug-map-south_africa.png", 
+        "ug-flag-guatemala.png", 
+        "ug-map-turkey.png", 
+        "ug-map-gabon.png", 
+        "ug-map-papua_new_guinea.png", 
+        "ug-flag-latvia.svg", 
+        "ug-flag-saudi_arabia.svg", 
+        "ug-map-austria.png", 
+        "ug-flag-syria.svg", 
+        "ug-map-russia.png", 
+        "ug-flag-bhutan.svg", 
+        "ug-flag-grenada.svg", 
+        "ug-flag-togo.svg", 
+        "ug-flag-artsakh.svg", 
+        "ug-flag-albania.svg", 
+        "ug-map-polynesia.jpg", 
+        "ug-flag-germany.svg", 
+        "ug-map-samoa.png", 
+        "ug-map-caribbean_sea.jpg", 
+        "ug-map-suriname.png", 
+        "ug-map-australia.png", 
+        "ug-flag-cyprus.svg", 
+        "ug-map-bolivia.png", 
+        "ug-map-east_siberian_sea.jpg", 
+        "ug-map-denmark.png", 
+        "ug-flag-united_kingdom.svg", 
+        "ug-map-east_timor.png", 
+        "ug-map-guam.png", 
+        "ug-map-guinea.png", 
+        "ug-flag-paraguay.svg", 
+        "ug-flag-nauru.svg", 
+        "ug-flag-somalia.svg", 
+        "ug-flag-guinea-bissau.svg", 
+        "ug-map-galapagos_islands.jpg", 
+        "ug-map-morocco.png", 
+        "ug-map-ukraine.png", 
+        "ug-map-tasman_sea.jpg", 
+        "ug-flag-turkey.svg", 
+        "ug-map-mexico.png", 
+        "ug-map-saint_kitts_and_nevis.png", 
+        "ug-flag-mauritius.svg", 
+        "ug-map-finland.png", 
+        "ug-flag-cocos_islands.svg", 
+        "ug-map-rwanda.png", 
+        "ug-flag-uruguay.svg", 
+        "ug-map-bali.png", 
+        "ug-map-antigua_and_barbuda.png", 
+        "ug-map-melanesia.jpg", 
+        "ug-flag-netherlands.svg", 
+        "ug-map-bulgaria.png", 
+        "ug-map-grenada.png", 
+        "ug-flag-zanzibar.svg", 
+        "ug-flag-zambia.svg", 
+        "ug-map-zanzibar.jpg", 
+        "ug-flag-christmas_island.svg", 
+        "ug-flag-israel.svg", 
+        "ug-flag-france.svg", 
+        "ug-map-atlantic_ocean.jpg", 
+        "ug-map-northern_ireland.png", 
+        "ug-map-azores.jpg", 
+        "ug-flag-kiribati.svg", 
+        "ug-map-iran.png", 
+        "ug-map-red_sea.jpg", 
+        "ug-flag-north_korea.svg", 
+        "ug-map-macau.png", 
+        "ug-flag-colombia.svg"
+    ], 
+    "name": "Ultimate Geography (DE)", 
+    "note_models": [
+        {
+            "__type__": "NoteModel", 
+            "crowdanki_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "css": ".card {\n  background-color: white;\n  color: black;\n  font-family: Verdana;\n  font-size: 16px;\n  padding: 1em 0;\n  text-align: center;\n}\n\n.type {\n  color: #333;\n  font-size: 70%;\n  font-weight: bold;\n  margin-bottom: .25em;\n  text-transform: uppercase;\n}\n\n.type--top {\n  margin-top: 1em;\n}\n\n.value {\n  font-size: 150%;\n}\n\n.flag img {\n  box-shadow: 3px 3px 3px rgba(0, 0, 0, .3);\n}\n\n.info {\n  color: #333;\n  font-size: 90%;\n  font-style: italic;\n  margin: .75em auto;\n  max-width: 30em;\n}\n\n.info + .info {\n  margin-top: -.375em;\n}\n\n#answer {\n  margin: 1.5em 0;\n}", 
+            "flds": [
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Country", 
+                    "ord": 0, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Country info", 
+                    "ord": 1, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Capital", 
+                    "ord": 2, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Capital info", 
+                    "ord": 3, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Capital hint", 
+                    "ord": 4, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Flag", 
+                    "ord": 5, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Flag similarity", 
+                    "ord": 6, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }, 
+                {
+                    "font": "Arial", 
+                    "media": [], 
+                    "name": "Map", 
+                    "ord": 7, 
+                    "rtl": false, 
+                    "size": 20, 
+                    "sticky": false
+                }
+            ], 
+            "latexPost": "\\end{document}", 
+            "latexPre": "\\documentclass[12pt]{article}\n\\special{papersize=3in,5in}\n\\usepackage{amssymb,amsmath}\n\\pagestyle{empty}\n\\setlength{\\parindent}{0in}\n\\begin{document}\n", 
+            "name": "Ultimate Geography (DE)-9dc01", 
+            "req": [
+                [
+                    0, 
+                    "all", 
+                    [
+                        2
+                    ]
+                ], 
+                [
+                    1, 
+                    "all", 
+                    [
+                        2
+                    ]
+                ], 
+                [
+                    2, 
+                    "all", 
+                    [
+                        5
+                    ]
+                ], 
+                [
+                    3, 
+                    "all", 
+                    [
+                        7
+                    ]
+                ]
+            ], 
+            "sortf": 0, 
+            "tags": [
+                "UG::Continents"
+            ], 
+            "tmpls": [
+                {
+                    "afmt": "{{FrontSide}}\n\n<hr id=answer>\n\n<div class=\"type\">Capital</div>\n<div class=\"value\">{{Capital}}</div>\n{{#Capital info}}<div class=\"info\">{{Capital info}}</div>{{/Capital info}}", 
+                    "bafmt": "", 
+                    "bqfmt": "", 
+                    "did": null, 
+                    "name": "Country > Capital", 
+                    "ord": 0, 
+                    "qfmt": "{{#Capital}}\n  <div class=\"type type--top\">Country</div>\n  <div class=\"value\">{{Country}}</div>\n  {{#Country info}}<div class=\"info\">{{Country info}}</div>{{/Country info}}\n{{/Capital}}"
+                }, 
+                {
+                    "afmt": "{{FrontSide}}\n\n<hr id=answer>\n\n<div class=\"type\">Country</div>\n<div class=\"value\">{{Country}}</div>\n{{#Country info}}<div class=\"info\">{{Country info}}</div>{{/Country info}}", 
+                    "bafmt": "", 
+                    "bqfmt": "", 
+                    "did": null, 
+                    "name": "Capital > Country", 
+                    "ord": 1, 
+                    "qfmt": "{{#Capital}}\n  <div class=\"type type--top\">Capital</div>\n  <div class=\"value\">{{Capital}}</div>\n  {{#Capital hint}}<div class=\"info\">Hint: {{Capital hint}}</div>{{/Capital hint}}\n{{/Capital}}\n"
+                }, 
+                {
+                    "afmt": "{{FrontSide}}\n\n<hr id=answer>\n\n<div class=\"value\">{{Country}}</div>\n{{#Country info}}<div class=\"info\">{{Country info}}</div>{{/Country info}}\n{{#Flag similarity}}<div class=\"info\">Flag similar to {{Flag similarity}}.</div>{{/Flag similarity}}", 
+                    "bafmt": "", 
+                    "bfont": "Arial", 
+                    "bqfmt": "", 
+                    "bsize": 12, 
+                    "did": null, 
+                    "name": "Flag > Country", 
+                    "ord": 2, 
+                    "qfmt": "{{#Flag}}\n  <div class=\"flag\">{{Flag}}</div>\n{{/Flag}}"
+                }, 
+                {
+                    "afmt": "{{FrontSide}}\n\n<hr id=answer>\n\n<div class=\"value\">{{Country}}</div>\n{{#Country info}}<div class=\"info\">{{Country info}}</div>{{/Country info}}", 
+                    "bafmt": "", 
+                    "bfont": "Arial", 
+                    "bqfmt": "", 
+                    "bsize": 12, 
+                    "did": null, 
+                    "name": "Map > Country", 
+                    "ord": 3, 
+                    "qfmt": "{{#Map}}\n  <div class=\"map\">{{Map}}</div>\n{{/Map}}"
+                }
+            ], 
+            "type": 0, 
+            "vers": []
+        }
+    ], 
+    "notes": [
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "England", 
+                "Constituent country of the United Kingdom.", 
+                "London", 
+                "", 
+                "Constituent country", 
+                "<img src=\"ug-flag-england.svg\" />", 
+                "", 
+                "<img src=\"ug-map-england.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "NlzO[tr0q:", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Scotland", 
+                "Constituent country of the United Kingdom.", 
+                "Edinburgh", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-scotland.svg\" />", 
+                "", 
+                "<img src=\"ug-map-scotland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Qa5jY_;vik", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "United Kingdom", 
+                "", 
+                "London", 
+                "", 
+                "Sovereign country", 
+                "<img src=\"ug-flag-united_kingdom.svg\" />", 
+                "", 
+                "<img src=\"ug-map-united_kingdom.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "l0Xp?kb3Wq", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Northern Ireland", 
+                "Constituent country of the United Kingdom.", 
+                "Belfast", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-northern_ireland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "n],X=9TP:0", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "France", 
+                "", 
+                "Paris", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-france.svg\" />", 
+                "", 
+                "<img src=\"ug-map-france.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gPon{*<#?.", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Wales", 
+                "Constituent country of the United Kingdom.", 
+                "Cardiff", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-wales.svg\" />", 
+                "", 
+                "<img src=\"ug-map-wales.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "B5I[@eWH5*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Georgia", 
+                "", 
+                "Tbilisi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-georgia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-georgia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "O*Xkr0Ya([", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Germany", 
+                "", 
+                "Berlin", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-germany.svg\" />", 
+                "", 
+                "<img src=\"ug-map-germany.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "MBgN.T69bb", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Greece", 
+                "", 
+                "Athens", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-greece.svg\" />", 
+                "", 
+                "<img src=\"ug-map-greece.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "bZFaPP,U}f", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Greenland", 
+                "Self-governing territory of Denmark.", 
+                "Nuuk", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-greenland.svg\" />", 
+                "", 
+                "<img src=\"ug-map-greenland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "w{}PiH-Fwg", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Hungary", 
+                "", 
+                "Budapest", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-hungary.svg\" />", 
+                "", 
+                "<img src=\"ug-map-hungary.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "co(<NG?DNf", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Albania", 
+                "", 
+                "Tirana", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-albania.svg\" />", 
+                "", 
+                "<img src=\"ug-map-albania.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gJ];:{[a1;", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Andorra", 
+                "", 
+                "Andorra la Vella", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-andorra.png\" />", 
+                "", 
+                "<img src=\"ug-map-andorra.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "DQKC*Gv%15", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Austria", 
+                "", 
+                "Vienna", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-austria.svg\" />", 
+                "Latvia (darker red, narrower white band)", 
+                "<img src=\"ug-map-austria.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sm7kjR_uIl", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Azerbaijan", 
+                "", 
+                "Baku", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-azerbaijan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-azerbaijan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "g3|xpW?OVU", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Belarus", 
+                "", 
+                "Minsk", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-belarus.svg\" />", 
+                "", 
+                "<img src=\"ug-map-belarus.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "zT-]c9O!hw", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Belgium", 
+                "", 
+                "Brussels", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-belgium.svg\" />", 
+                "", 
+                "<img src=\"ug-map-belgium.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Gc1.l6j/mq", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bosnia and Herzegovina", 
+                "", 
+                "Sarajevo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bosnia_and_herzegovina.svg\" />", 
+                "", 
+                "<img src=\"ug-map-bosnia_and_herzegovina.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "P{=HpT]g}o", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bulgaria", 
+                "", 
+                "Sofia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bulgaria.svg\" />", 
+                "", 
+                "<img src=\"ug-map-bulgaria.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "jdHpfS/odQ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Croatia", 
+                "", 
+                "Zagreb", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-croatia.png\" />", 
+                "", 
+                "<img src=\"ug-map-croatia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "JGAaX>JT:K", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Czech Republic", 
+                "", 
+                "Prague", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-czech_republic.svg\" />", 
+                "", 
+                "<img src=\"ug-map-czech_republic.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "x}6r$7=s$6", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Denmark", 
+                "", 
+                "Copenhagen", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-denmark.svg\" />", 
+                "", 
+                "<img src=\"ug-map-denmark.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "GxGMh`Kn91", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Estonia", 
+                "", 
+                "Tallinn", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-estonia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-estonia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "EdE!W)q:?e", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Faroe Islands", 
+                "Self-governing territory of Denmark.", 
+                "Tórshavn", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-faroe_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-faroe_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "b~G&j:hkX,", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Finland", 
+                "", 
+                "Helsinki", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-finland.svg\" />", 
+                "", 
+                "<img src=\"ug-map-finland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gsdE|#zAPQ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Iceland", 
+                "", 
+                "Reykjavík", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-iceland.svg\" />", 
+                "Norway (red background, blue cross)", 
+                "<img src=\"ug-map-iceland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "y.m;&I#Ap3", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ireland", 
+                "", 
+                "Dublin", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-ireland.svg\" />", 
+                "Côte d'Ivoire (green and orange flipped)", 
+                "<img src=\"ug-map-ireland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "t_1Lsi>{jR", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Italy", 
+                "", 
+                "Rome", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-italy.svg\" />", 
+                "", 
+                "<img src=\"ug-map-italy.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "qajb-qA6r%", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Latvia", 
+                "", 
+                "Riga", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-latvia.svg\" />", 
+                "Austria (brighter red, wider white band)", 
+                "<img src=\"ug-map-latvia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "H-W0hqgU^0", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Liechtenstein", 
+                "", 
+                "Vaduz", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-liechtenstein.svg\" />", 
+                "", 
+                "<img src=\"ug-map-liechtenstein.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f,z8x?-`%]", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Lithuania", 
+                "", 
+                "Vilnius", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-lithuania.svg\" />", 
+                "", 
+                "<img src=\"ug-map-lithuania.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gY<iEN8ltb", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Luxembourg", 
+                "", 
+                "Luxembourg", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-luxembourg.svg\" />", 
+                "Netherlands (darker blue)", 
+                "<img src=\"ug-map-luxembourg.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "iBKM2`|*3[", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Macedonia", 
+                "", 
+                "Skopje", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-macedonia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-macedonia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Hwya0~5e6G", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Malta", 
+                "", 
+                "Valletta", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-malta.svg\" />", 
+                "", 
+                "<img src=\"ug-map-malta.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "xCbG!#ym<,", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Moldova", 
+                "", 
+                "Chișinău", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-moldova.svg\" />", 
+                "", 
+                "<img src=\"ug-map-moldova.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ewd21$-,_4", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Monaco", 
+                "", 
+                "Monaco", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-monaco.svg\" />", 
+                "Indonesia (slightly wider) and Poland (colours flipped)", 
+                "<img src=\"ug-map-monaco.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "E1}*9O543T", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Montenegro", 
+                "", 
+                "Podgorica", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-montenegro.png\" />", 
+                "", 
+                "<img src=\"ug-map-montenegro.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "b=UY<Wh.Y^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Netherlands", 
+                "", 
+                "Amsterdam", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-netherlands.svg\" />", 
+                "Luxembourg (lighter blue)", 
+                "<img src=\"ug-map-netherlands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "xdZqaj;yil", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Norway", 
+                "", 
+                "Oslo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-norway.svg\" />", 
+                "", 
+                "<img src=\"ug-map-norway.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Q7L;W#N=h3", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Poland", 
+                "", 
+                "Warsaw", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-poland.svg\" />", 
+                "Indonesia and Monaco (colours flipped)", 
+                "<img src=\"ug-map-poland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "er$w2QA-U5", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Portugal", 
+                "", 
+                "Lisbon", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-portugal.svg\" />", 
+                "", 
+                "<img src=\"ug-map-portugal.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "HxwL.1_V!^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Romania", 
+                "", 
+                "Bucharest", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-romania.svg\" />", 
+                "Chad (slightly darker blue)", 
+                "<img src=\"ug-map-romania.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "NC9&P.5?X`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Russia", 
+                "", 
+                "Moscow", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-russia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-russia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "m$nvA0z9PL", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "San Marino", 
+                "", 
+                "City of San Marino", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-san_marino.png\" />", 
+                "", 
+                "<img src=\"ug-map-san_marino.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "cK9Z:-*8Wk", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Serbia", 
+                "", 
+                "Belgrade", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-serbia.png\" />", 
+                "", 
+                "<img src=\"ug-map-serbia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "q}g^^n:;5R", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Slovakia", 
+                "", 
+                "Bratislava", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-slovakia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-slovakia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "QFBK4T56xa", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Slovenia", 
+                "", 
+                "Ljubljana", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-slovenia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-slovenia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "n30>p~j-|,", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Spain", 
+                "", 
+                "Madrid", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-spain.png\" />", 
+                "", 
+                "<img src=\"ug-map-spain.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "yzH,Vl`rC]", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sweden", 
+                "", 
+                "Stockholm", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sweden.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sweden.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "o~X<?:w<EY", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::European_Union", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Switzerland", 
+                "", 
+                "Bern", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-switzerland.svg\" />", 
+                "", 
+                "<img src=\"ug-map-switzerland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Pg01UIw%yY", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Turkey", 
+                "", 
+                "Ankara", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-turkey.svg\" />", 
+                "", 
+                "<img src=\"ug-map-turkey.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "D/tQ~C3_,p", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ukraine", 
+                "", 
+                "Kiev", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-ukraine.svg\" />", 
+                "", 
+                "<img src=\"ug-map-ukraine.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "o}+;GRUum`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Vatican City", 
+                "", 
+                "Vatican City", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-vatican_city.svg\" />", 
+                "", 
+                "<img src=\"ug-map-vatican_city.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "d58(HJY@rx", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Armenia", 
+                "", 
+                "Yerevan", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-armenia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-armenia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Azc+<|1_I<", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cyprus", 
+                "", 
+                "Nicosia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cyprus.svg\" />", 
+                "", 
+                "<img src=\"ug-map-cyprus.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "y_T4PFCc~v", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::European_Union", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kazakhstan", 
+                "", 
+                "Astana", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kazakhstan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kazakhstan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "rXD5}Y8J|;", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Egypt", 
+                "", 
+                "Cairo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-egypt.svg\" />", 
+                "Yemen (no emblem)", 
+                "<img src=\"ug-map-egypt.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "G6}!tA)I,Q", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Algeria", 
+                "", 
+                "Algiers", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-algeria.svg\" />", 
+                "", 
+                "<img src=\"ug-map-algeria.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "H`H-bfQDZz", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Angola", 
+                "", 
+                "Luanda", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-angola.svg\" />", 
+                "", 
+                "<img src=\"ug-map-angola.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Rc]C_6hI>a", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Benin", 
+                "", 
+                "Porto-Novo", 
+                "While Porto-Novo is the official capital, Cotonou is the de facto seat of government.", 
+                "", 
+                "<img src=\"ug-flag-benin.svg\" />", 
+                "", 
+                "<img src=\"ug-map-benin.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "L_=y&G^;&E", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Botswana", 
+                "", 
+                "Gaborone", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-botswana.svg\" />", 
+                "", 
+                "<img src=\"ug-map-botswana.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "LXL/MOy&7W", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Burkina Faso", 
+                "", 
+                "Ouagadougou", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-burkina_faso.svg\" />", 
+                "", 
+                "<img src=\"ug-map-burkina_faso.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "r?XA$RTFYW", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cameroon", 
+                "", 
+                "Yaoundé", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cameroon.svg\" />", 
+                "Senegal (green/yellow/red, green star)", 
+                "<img src=\"ug-map-cameroon.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Nt{6)RqhF[", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Burundi", 
+                "", 
+                "Bujumbura", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-burundi.svg\" />", 
+                "", 
+                "<img src=\"ug-map-burundi.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "c;J0}V{?8#", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cape Verde", 
+                "", 
+                "Praia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cape_verde.svg\" />", 
+                "", 
+                "<img src=\"ug-map-cape_verde.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "q(Zhj/z{*P", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "São Tomé and Príncipe", 
+                "", 
+                "São Tomé", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sao_tome_and_principe.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sao_tome_and_principe.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Iat0[^o;s$", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Central African Republic", 
+                "", 
+                "Bangui", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-central_african_republic.svg\" />", 
+                "", 
+                "<img src=\"ug-map-central_african_republic.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "McT|&u8^B!", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Chad", 
+                "", 
+                "N'Djamena", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-chad.svg\" />", 
+                "Romania (slightly lighter blue)", 
+                "<img src=\"ug-map-chad.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wP%-UK#S]k", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Equatorial Guinea", 
+                "", 
+                "Malabo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-equatorial_guinea.svg\" />", 
+                "", 
+                "<img src=\"ug-map-equatorial_guinea.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "byT&OaE7z+", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kenya", 
+                "", 
+                "Nairobi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kenya.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kenya.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "D6N1uWiw}h", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Comoros", 
+                "", 
+                "Moroni", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-comoros.svg\" />", 
+                "", 
+                "<img src=\"ug-map-comoros.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "K7+n<DispB", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ivory Coast (Côte d'Ivoire)", 
+                "", 
+                "Yamoussoukro", 
+                "While Yamoussoukro is the official capital, Abidjan is the de facto seat of government.", 
+                "", 
+                "<img src=\"ug-flag-ivory_coast.svg\" />", 
+                "Ireland (orange and green flipped)", 
+                "<img src=\"ug-map-ivory_coast.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "vIgl+rIJcZ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Democratic Republic of the Congo", 
+                "Formerly Zaire.", 
+                "Kinshasa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-democratic_republic_of_the_congo.svg\" />", 
+                "", 
+                "<img src=\"ug-map-democratic_republic_of_the_congo.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "H+/Y&6uoak", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Djibouti", 
+                "", 
+                "Djibouti", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-djibouti.svg\" />", 
+                "", 
+                "<img src=\"ug-map-djibouti.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sT6h*&DB{Z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guinea-Bissau", 
+                "", 
+                "Bissau", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-guinea-bissau.svg\" />", 
+                "", 
+                "<img src=\"ug-map-guinea-bissau.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "otvKCl=|yI", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Eritrea", 
+                "", 
+                "Asmara", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-eritrea.svg\" />", 
+                "", 
+                "<img src=\"ug-map-eritrea.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ql*EyZZUpY", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ethiopia", 
+                "", 
+                "Addis Ababa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-ethiopia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-ethiopia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "cha9Wt)iE=", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Gabon", 
+                "", 
+                "Libreville", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-gabon.svg\" />", 
+                "", 
+                "<img src=\"ug-map-gabon.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "mXQuj8j09N", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "The Gambia", 
+                "", 
+                "Banjul", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-the_gambia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-the_gambia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "qIAdJL1!on", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Lesotho", 
+                "", 
+                "Maseru", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-lesotho.svg\" />", 
+                "", 
+                "<img src=\"ug-map-lesotho.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "H}}Jt9iy*]", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Liberia", 
+                "", 
+                "Monrovia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-liberia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-liberia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "mV$$CZEnMb", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Madagascar", 
+                "", 
+                "Antananarivo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-madagascar.svg\" />", 
+                "", 
+                "<img src=\"ug-map-madagascar.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "qVhq/di]oU", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Malawi", 
+                "", 
+                "Lilongwe", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-malawi.svg\" />", 
+                "", 
+                "<img src=\"ug-map-malawi.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "lqRKYzQr7~", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mali", 
+                "", 
+                "Bamako", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mali.svg\" />", 
+                "Guinea (green and red flipped, slightly darker green)", 
+                "<img src=\"ug-map-mali.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "h(+s?d:gIi", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mauritania", 
+                "", 
+                "Nouakchot", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mauritania.svg\" />", 
+                "", 
+                "<img src=\"ug-map-mauritania.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "r@t?5hlV.?", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mauritius", 
+                "", 
+                "Port Louis", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mauritius.svg\" />", 
+                "", 
+                "<img src=\"ug-map-mauritius.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sEfPmt<5@7", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Morocco", 
+                "", 
+                "Rabat", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-morocco.svg\" />", 
+                "", 
+                "<img src=\"ug-map-morocco.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Gu0ob*A(e`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mozambique", 
+                "", 
+                "Maputo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mozambique.svg\" />", 
+                "", 
+                "<img src=\"ug-map-mozambique.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ORroqh+9oZ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Namibia", 
+                "", 
+                "Windhoek", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-namibia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-namibia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "hnj|*uQ#pR", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Niger", 
+                "", 
+                "Niamey", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-niger.svg\" />", 
+                "", 
+                "<img src=\"ug-map-niger.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Gj-l3^m46p", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Nigeria", 
+                "", 
+                "Abuja", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-nigeria.svg\" />", 
+                "", 
+                "<img src=\"ug-map-nigeria.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "k-|0:M^mhZ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Republic of the Congo", 
+                "", 
+                "Brazzaville", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-republic_of_the_congo.svg\" />", 
+                "", 
+                "<img src=\"ug-map-republic_of_the_congo.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "AA8N2UR7~W", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Rwanda", 
+                "", 
+                "Kigali", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-rwanda.svg\" />", 
+                "", 
+                "<img src=\"ug-map-rwanda.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "e:|x$xJf^O", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Senegal", 
+                "", 
+                "Dakar", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-senegal.svg\" />", 
+                "Cameroon (green/red/yellow, yellow&nbsp;star)", 
+                "<img src=\"ug-map-senegal.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "rEA6(:#saR", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Seychelles", 
+                "", 
+                "Victoria", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-seychelles.svg\" />", 
+                "", 
+                "<img src=\"ug-map-seychelles.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Kaah8pns<4", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sierra Leone", 
+                "", 
+                "Freetown", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sierra_leone.svg\" />", 
+                "Galápagos Islands (slightly darker blue)", 
+                "<img src=\"ug-map-sierra_leone.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "DM-}~]GT9n", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "South Africa", 
+                "", 
+                "Pretoria", 
+                "South Africa has no legally defined capital: the branches of government are split over three cities: Pretoria (executive), Cape Town (legislative) and Bloemfontein (judicial).", 
+                "", 
+                "<img src=\"ug-flag-south_africa.svg\" />", 
+                "", 
+                "<img src=\"ug-map-south_africa.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "J=|N1nyKor", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sudan", 
+                "", 
+                "Khartoum", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sudan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sudan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "GjKz57VYo>", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Swaziland", 
+                "", 
+                "Lobamba", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-swaziland.svg\" />", 
+                "", 
+                "<img src=\"ug-map-swaziland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "oe+)1Mea.=", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tanzania", 
+                "", 
+                "Dodoma", 
+                "While Dodoma is the official capital, Dar es Salaam is the de facto seat of government.", 
+                "", 
+                "<img src=\"ug-flag-tanzania.svg\" />", 
+                "", 
+                "<img src=\"ug-map-tanzania.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "oXxtm-sLJd", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Togo", 
+                "", 
+                "Lomé", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-togo.svg\" />", 
+                "", 
+                "<img src=\"ug-map-togo.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "b*F_>0w#gM", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tunisia", 
+                "", 
+                "Tunis", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-tunisia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-tunisia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "q,6eq0rTX[", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Uganda", 
+                "", 
+                "Kampala", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-uganda.svg\" />", 
+                "", 
+                "<img src=\"ug-map-uganda.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "FPuH:7L#<m", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sahrawi Republic", 
+                "Partially recognised state claimed by Morocco.", 
+                "El Aaiún", 
+                "While El Aaiún is the declared capital,&nbsp;Tifariti is the de facto seat of government.", 
+                "", 
+                "<img src=\"ug-flag-sahrawi_republic.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sahrawi_republic.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f1[+dC^l+&", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Zambia", 
+                "", 
+                "Lusaka", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-zambia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-zambia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "zq/PkdqsY+", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Zimbabwe", 
+                "", 
+                "Harare", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-zimbabwe.svg\" />", 
+                "", 
+                "<img src=\"ug-map-zimbabwe.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "fj%:@B1ATk", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Canary Islands", 
+                "Autonomous community of Spain.", 
+                "Santa Cruz and Las Palmas", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-canary_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-canary_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "H7Dlg->^P`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Afghanistan", 
+                "", 
+                "Kabul", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-afghanistan.png\" />", 
+                "", 
+                "<img src=\"ug-map-afghanistan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "iVy(00/TmS", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bahrain", 
+                "", 
+                "Manama", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bahrain.svg\" />", 
+                "Qatar (wider, more serrated edges, purple/maroon)", 
+                "<img src=\"ug-map-bahrain.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "G{D4Me1=iO", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bangladesh", 
+                "", 
+                "Dhaka", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bangladesh.svg\" />", 
+                "", 
+                "<img src=\"ug-map-bangladesh.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "M|=Bw-dAEP", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bhutan", 
+                "", 
+                "Thimphu", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bhutan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-bhutan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "qai#$m/DF`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Brunei", 
+                "", 
+                "Bandar Seri Begawan", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-brunei.svg\" />", 
+                "", 
+                "<img src=\"ug-map-brunei.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "N|Y`xq13SU", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "China", 
+                "", 
+                "Beijing", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-china.svg\" />", 
+                "", 
+                "<img src=\"ug-map-china.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Ks1LBNG9/x", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cambodia", 
+                "", 
+                "Phnom Penh", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cambodia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-cambodia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Ng!5ZA7F}4", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Indonesia", 
+                "", 
+                "Jakarta", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-indonesia.svg\" />", 
+                "Monaco (slightly narrower) and Poland (colours flipped)", 
+                "<img src=\"ug-map-indonesia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "iSt.iz0Pa4", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "India", 
+                "", 
+                "New Delhi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-india.svg\" />", 
+                "", 
+                "<img src=\"ug-map-india.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "C`|]_@BJi1", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Hong Kong", 
+                "Special Administrative Region of China.", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-hong_kong.svg\" />", 
+                "", 
+                "<img src=\"ug-map-hong_kong.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "bit|Iy@I&~", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Iran", 
+                "", 
+                "Tehran", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-iran.svg\" />", 
+                "", 
+                "<img src=\"ug-map-iran.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "K!([z%8q#Z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Israel", 
+                "", 
+                "Jerusalem", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-israel.svg\" />", 
+                "", 
+                "<img src=\"ug-map-israel.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "bJR=I~k?$[", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Iraq", 
+                "", 
+                "Baghdad", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-iraq.svg\" />", 
+                "", 
+                "<img src=\"ug-map-iraq.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "BD+)bi0:jU", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "South Korea", 
+                "", 
+                "Seoul", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-south_korea.svg\" />", 
+                "", 
+                "<img src=\"ug-map-south_korea.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "k{aFX@(P7R", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "North Korea", 
+                "", 
+                "Pyongyang", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-north_korea.svg\" />", 
+                "", 
+                "<img src=\"ug-map-north_korea.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "NIXV^x,R&v", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Jordan", 
+                "", 
+                "Amman", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-jordan.svg\" />", 
+                "Palestine (no star, shorter arrow)", 
+                "<img src=\"ug-map-jordan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sZ75*I)~|h", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Japan", 
+                "", 
+                "Tokyo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-japan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-japan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ngewm`3r^k", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Lebanon", 
+                "", 
+                "Beirut", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-lebanon.svg\" />", 
+                "", 
+                "<img src=\"ug-map-lebanon.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wz/CAf4:5;", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Laos", 
+                "", 
+                "Vientiane", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-laos.svg\" />", 
+                "", 
+                "<img src=\"ug-map-laos.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "jV0r;A](vw", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kyrgyzstan", 
+                "", 
+                "Bishkek", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kyrgyzstan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kyrgyzstan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "lG:2[YV!Am", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kuwait", 
+                "", 
+                "Kuwait City", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kuwait.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kuwait.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "zBd6C5~v=T", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Myanmar", 
+                "Also known as Burma.", 
+                "Naypyidaw", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-myanmar.svg\" />", 
+                "", 
+                "<img src=\"ug-map-myanmar.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "l~|7?)y$WJ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mongolia", 
+                "", 
+                "Ulaanbaatar", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mongolia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-mongolia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "PfgLXeS7h4", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Maldives", 
+                "", 
+                "Malé", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-maldives.svg\" />", 
+                "", 
+                "<img src=\"ug-map-maldives.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "G7#M9O2cKi", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Malaysia", 
+                "", 
+                "Kuala Lumpur", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-malaysia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-malaysia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "o*xM[jEnr?", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Oman", 
+                "", 
+                "Muscat", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-oman.svg\" />", 
+                "", 
+                "<img src=\"ug-map-oman.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f:v/dzqd.g", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Nepal", 
+                "", 
+                "Kathmandu", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-nepal.svg\" />", 
+                "", 
+                "<img src=\"ug-map-nepal.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "F[*H->)Jm}", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Palestine", 
+                "", 
+                "Ramallah", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-palestine.svg\" />", 
+                "Jordan (white star in arrow, longer arrow)", 
+                "<img src=\"ug-map-palestine.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f!41wI}}L/", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Pakistan", 
+                "", 
+                "Islamabad", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-pakistan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-pakistan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f^:2W+~y$*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Qatar", 
+                "", 
+                "Doha", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-qatar.svg\" />", 
+                "Bahrain (narrower, fewer serrated edges, red)", 
+                "<img src=\"ug-map-qatar.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "LU0I$EKbCP", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Saudi Arabia", 
+                "", 
+                "Riyadh", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-saudi_arabia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-saudi_arabia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "CTBl.8!KlS", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Singapore", 
+                "", 
+                "Singapore", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-singapore.svg\" />", 
+                "", 
+                "<img src=\"ug-map-singapore.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "y!uuj~?NjY", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Syria", 
+                "", 
+                "Damascus", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-syria.svg\" />", 
+                "", 
+                "<img src=\"ug-map-syria.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "u$b^X[Bvsg", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Taiwan", 
+                "Partially recognised state claimed by China.", 
+                "Taipei", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-taiwan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-taiwan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "M0`F)gg(+S", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sri Lanka", 
+                "", 
+                "Colombo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sri_lanka.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sri_lanka.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Db<qViDKhQ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tajikistan", 
+                "", 
+                "Dushanbe", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-tajikistan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-tajikistan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "HsRMJ9+$NT", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Thailand", 
+                "", 
+                "Bangkok", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-thailand.svg\" />", 
+                "Costa Rica (blue and red&nbsp;inverted)", 
+                "<img src=\"ug-map-thailand.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "D=0/i@.9#p", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "East Timor", 
+                "Also known as&nbsp;Timor-Leste.", 
+                "Dili", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-east_timor.svg\" />", 
+                "", 
+                "<img src=\"ug-map-east_timor.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ce7`gQ%8Z:", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "United Arab Emirates", 
+                "", 
+                "Abu Dhabi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-united_arab_emirates.svg\" />", 
+                "", 
+                "<img src=\"ug-map-united_arab_emirates.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "eZ^0w4Y!_U", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Turkmenistan", 
+                "", 
+                "Ashgabat", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-turkmenistan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-turkmenistan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "A=_=c&@x|X", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Yemen", 
+                "", 
+                "Sana'a", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-yemen.svg\" />", 
+                "Egypt (with emblem)", 
+                "<img src=\"ug-map-yemen.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "yH|Lxg]A:6", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Vietnam", 
+                "", 
+                "Hanoi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-vietnam.svg\" />", 
+                "", 
+                "<img src=\"ug-map-vietnam.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "s%D9}_}h{2", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Uzbekistan", 
+                "", 
+                "Tashkent", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-uzbekistan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-uzbekistan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ME`&9>po[{", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Fiji", 
+                "", 
+                "Suva", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-fiji.png\" />", 
+                "", 
+                "<img src=\"ug-map-fiji.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "DnhLL+^]%d", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Papua New Guinea", 
+                "", 
+                "Port Moresby", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-papua_new_guinea.svg\" />", 
+                "", 
+                "<img src=\"ug-map-papua_new_guinea.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "C:#vO{x8@r", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Australia", 
+                "", 
+                "Canberra", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-australia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-australia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "b/,=[-EPE^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Solomon Islands", 
+                "", 
+                "Honiara", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-solomon_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-solomon_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "luzVTzFfQn", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Argentina", 
+                "", 
+                "Buenos Aires", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-argentina.svg\" />", 
+                "", 
+                "<img src=\"ug-map-argentina.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "cM:&MOF[),", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bolivia", 
+                "", 
+                "Sucre", 
+                "While Sucre is the constitutional capital, La Paz is the seat of government.", 
+                "", 
+                "<img src=\"ug-flag-bolivia.png\" />", 
+                "", 
+                "<img src=\"ug-map-bolivia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "HU+1<vLMSs", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Brazil", 
+                "", 
+                "Brasilia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-brazil.svg\" />", 
+                "", 
+                "<img src=\"ug-map-brazil.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "hT#gX~RIW)", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Chile", 
+                "", 
+                "Santiago", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-chile.svg\" />", 
+                "", 
+                "<img src=\"ug-map-chile.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "r-D`St2.4U", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Colombia", 
+                "", 
+                "Bogotá", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-colombia.svg\" />", 
+                "Ecuador (with coat of arms)", 
+                "<img src=\"ug-map-colombia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "CsECxFke>M", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ecuador", 
+                "", 
+                "Quito", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-ecuador.png\" />", 
+                "Colombia (no coat of arms)", 
+                "<img src=\"ug-map-ecuador.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "cQ.v%TE/$Z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guyana", 
+                "", 
+                "Georgetown", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-guyana.svg\" />", 
+                "", 
+                "<img src=\"ug-map-guyana.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "zZm~(?3e7F", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Paraguay", 
+                "", 
+                "Asunción", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-paraguay.svg\" />", 
+                "", 
+                "<img src=\"ug-map-paraguay.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "h{$+6$gxv8", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Peru", 
+                "", 
+                "Lima", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-peru.svg\" />", 
+                "", 
+                "<img src=\"ug-map-peru.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "z.K@smfTed", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Suriname", 
+                "", 
+                "Paramaribo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-suriname.svg\" />", 
+                "", 
+                "<img src=\"ug-map-suriname.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "FsTYYYeu/M", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Uruguay", 
+                "", 
+                "Montevideo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-uruguay.svg\" />", 
+                "", 
+                "<img src=\"ug-map-uruguay.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ci;~q^4)N;", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Venezuela", 
+                "", 
+                "Caracas", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-venezuela.svg\" />", 
+                "", 
+                "<img src=\"ug-map-venezuela.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "qOgBhJhhJ(", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cook Islands", 
+                "", 
+                "Avarua", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cook_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-cook_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "HAH!G/iFc_", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Federated States of Micronesia", 
+                "", 
+                "Palikir", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-federated_states_of_micronesia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-federated_states_of_micronesia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "O}Gp$W9;AI", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guam", 
+                "Unincorporated territory of the United States.", 
+                "Hagåtña", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-guam.svg\" />", 
+                "", 
+                "<img src=\"ug-map-guam.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "s=<].<8tPu", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Vanuatu", 
+                "", 
+                "Port Vila", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-vanuatu.svg\" />", 
+                "", 
+                "<img src=\"ug-map-vanuatu.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "xN*rb@mAir", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Canada", 
+                "", 
+                "Ottawa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-canada.svg\" />", 
+                "", 
+                "<img src=\"ug-map-canada.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "onJ^[^[GGg", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "United States of America", 
+                "", 
+                "Washington, D.C.", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-united_states_of_america.svg\" />", 
+                "", 
+                "<img src=\"ug-map-united_states_of_america.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "c?W4ySKos#", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mexico", 
+                "", 
+                "Mexico City", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mexico.png\" />", 
+                "", 
+                "<img src=\"ug-map-mexico.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": ">c,KC(,_p", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Puerto Rico", 
+                "Unincorporated territory of the United States.", 
+                "San Juan", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-puerto_rico.svg\" />", 
+                "Cuba (blue and red&nbsp;inverted)", 
+                "<img src=\"ug-map-puerto_rico.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "(SRcG?Gnk", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cuba", 
+                "", 
+                "Havana", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cuba.svg\" />", 
+                "Puerto Rico (red and blue inverted)", 
+                "<img src=\"ug-map-cuba.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "lT/W:^1s8A", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Dominican Republic", 
+                "", 
+                "Santo Domingo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-dominican_republic.png\" />", 
+                "", 
+                "<img src=\"ug-map-dominican_republic.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "nm+4d>qR.S", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Haiti", 
+                "", 
+                "Port-au-Prince", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-haiti.svg\" />", 
+                "", 
+                "<img src=\"ug-map-haiti.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "vsJ}<_-]uF", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Jamaica", 
+                "", 
+                "Kingston", 
+                "", 
+                "Caribbean", 
+                "<img src=\"ug-flag-jamaica.svg\" />", 
+                "", 
+                "<img src=\"ug-map-jamaica.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Q&TBT0b28Q", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Trinidad and Tobago", 
+                "", 
+                "Port of Spain", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-trinidad_and_tobago.svg\" />", 
+                "", 
+                "<img src=\"ug-map-trinidad_and_tobago.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "of#U3/nlYR", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bermuda", 
+                "Overseas territory of the United Kingdom.", 
+                "Hamilton", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bermuda.svg\" />", 
+                "", 
+                "<img src=\"ug-map-bermuda.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "c<9,.3)?38", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guadeloupe", 
+                "Overseas department of France.", 
+                "Basse-Terre", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-guadeloupe.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "c-N=]Ja@/x", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "The Bahamas", 
+                "", 
+                "Nassau", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-the_bahamas.svg\" />", 
+                "", 
+                "<img src=\"ug-map-the_bahamas.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "E:5h#>q]-)", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Barbados", 
+                "", 
+                "Bridgetown", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-barbados.svg\" />", 
+                "", 
+                "<img src=\"ug-map-barbados.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "B|j]4[d`iK", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Belize", 
+                "", 
+                "Belmopan", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-belize.png\" />", 
+                "", 
+                "<img src=\"ug-map-belize.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sFNcI5M3N*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Costa Rica", 
+                "", 
+                "San José", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-costa_rica.svg\" />", 
+                "Thailand (red and blue inverted)", 
+                "<img src=\"ug-map-costa_rica.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "MQK}fK@QpD", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "El Salvador", 
+                "", 
+                "San Salvador", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-el_salvador.png\" />", 
+                "Nicaragua (different emblem)", 
+                "<img src=\"ug-map-el_salvador.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "intNze*7+X", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guatemala", 
+                "", 
+                "Guatemala City", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-guatemala.png\" />", 
+                "", 
+                "<img src=\"ug-map-guatemala.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wDB`gZ%[d1", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Honduras", 
+                "", 
+                "Tegucigalpa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-honduras.svg\" />", 
+                "", 
+                "<img src=\"ug-map-honduras.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "xT!X8,wg[_", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Nicaragua", 
+                "", 
+                "Managua", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-nicaragua.svg\" />", 
+                "El Salvador (different emblem)", 
+                "<img src=\"ug-map-nicaragua.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "E(^_i(Rz)e", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Panama", 
+                "", 
+                "Panama City", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-panama.svg\" />", 
+                "", 
+                "<img src=\"ug-map-panama.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "d^ly#ijD:]", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::North+Central_America", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Antigua and Barbuda", 
+                "", 
+                "St. John's", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-antigua_and_barbuda.svg\" />", 
+                "", 
+                "<img src=\"ug-map-antigua_and_barbuda.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "MA^00_~X<^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Dominica", 
+                "", 
+                "Roseau", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-dominica.svg\" />", 
+                "", 
+                "<img src=\"ug-map-dominica.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "dtflI;Lbg[", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Saint Vincent and the Grenadines", 
+                "", 
+                "Kingstown", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-saint_vincent_and_the_grenadines.svg\" />", 
+                "", 
+                "<img src=\"ug-map-saint_vincent_and_the_grenadines.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "tx<;;?p>5Z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Somalia", 
+                "", 
+                "Mogadishu", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-somalia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-somalia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "lxIqtS/)1[", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Zanzibar", 
+                "Semi-autonomous region of Tanzania.", 
+                "Zanzibar City", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-zanzibar.svg\" />", 
+                "", 
+                "<img src=\"ug-map-zanzibar.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Eequm-Y;q0", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ghana", 
+                "", 
+                "Accra", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-ghana.svg\" />", 
+                "", 
+                "<img src=\"ug-map-ghana.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "n2/Z5p<u~|", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guinea", 
+                "", 
+                "Conakry", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-guinea.svg\" />", 
+                "Mali (red and&nbsp;green&nbsp;flipped, slightly brighter green)", 
+                "<img src=\"ug-map-guinea.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "lvnR<X0)jj", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "New Zealand", 
+                "", 
+                "Wellington", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-new_zealand.svg\" />", 
+                "", 
+                "<img src=\"ug-map-new_zealand.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "DvyzU3ow3", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "French Polynesia", 
+                "Overseas territory of France.", 
+                "Papeete", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-french_polynesia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-french_polynesia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "yN[]D{Du-c", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Philippines", 
+                "", 
+                "Manila", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-philippines.svg\" />", 
+                "", 
+                "<img src=\"ug-map-philippines.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "hI7Q&#I^6r", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Galápagos Islands", 
+                "Province of Ecuador.", 
+                "Puerto Baquerizo Moreno", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-galapagos_islands.svg\" />", 
+                "Sierra Leone (slightly lighter blue)", 
+                "<img src=\"ug-map-galapagos_islands.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "mr,D|JdZP~", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kosovo", 
+                "Partially recognised state claimed by Serbia.", 
+                "Pristina", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kosovo.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kosovo.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f]5pH%?q42", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Libya", 
+                "", 
+                "Tripoli", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-libya.svg\" />", 
+                "", 
+                "<img src=\"ug-map-libya.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "x%Yvm2Y,[c", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Palau", 
+                "", 
+                "Ngerulmud", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-palau.svg\" />", 
+                "", 
+                "<img src=\"ug-map-palau.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "e4>0vo,)`K", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Saint Lucia", 
+                "", 
+                "Castries", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-saint_lucia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-saint_lucia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "z,$qm/ApT)", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bali", 
+                "Province of Indonesia.", 
+                "Denpasar", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bali.png\" />", 
+                "", 
+                "<img src=\"ug-map-bali.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wwLt]JUWX0", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Grenada", 
+                "", 
+                "St. George's", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-grenada.svg\" />", 
+                "", 
+                "<img src=\"ug-map-grenada.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Ep9y}N~x2O", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bonaire", 
+                "Special municipality of the Netherlands.", 
+                "Kralendijk", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-bonaire.svg\" />", 
+                "", 
+                "<img src=\"ug-map-bonaire.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "q.[U#RB.d!", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "British Virgin Islands", 
+                "Overseas territory of the United Kingdom.", 
+                "Road Town", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-british_virgin_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-british_virgin_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "y|nek4{,lW", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Turks and Caicos Islands", 
+                "Overseas territory of the United Kingdom.", 
+                "Cockburn Town", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-turks_and_caicos_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-turks_and_caicos_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "EUD{|m@bn)", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cayman Islands", 
+                "Overseas territory of the United Kingdom.", 
+                "George Town", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cayman_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-cayman_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "g3`)?X*)T-", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Anguilla", 
+                "Overseas territory of the United Kingdom.", 
+                "The Valley", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-anguilla.svg\" />", 
+                "", 
+                "<img src=\"ug-map-anguilla.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "vkEBhx*=C#", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Azores", 
+                "Autonomous region of Portugal.", 
+                "Ponta Delgada", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-azores.svg\" />", 
+                "", 
+                "<img src=\"ug-map-azores.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "geSa78EU;a", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Ceuta", 
+                "Autonomous city of Spain.", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-ceuta.png\" />", 
+                "", 
+                "<img src=\"ug-map-ceuta.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "v4EVNfX~R+", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Christmas Island", 
+                "External territory of Australia.", 
+                "Flying Fish Cove", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-christmas_island.svg\" />", 
+                "", 
+                "<img src=\"ug-map-christmas_island.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "AJXb;)ZZfs", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Curaçao", 
+                "Constituent country of the Kingdom of the Netherlands.", 
+                "Willemstad", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-curacao.svg\" />", 
+                "", 
+                "<img src=\"ug-map-curacao.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "bdB=fgu%DF", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Easter Island", 
+                "Polynesian island and special territory of Chile.", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-easter_island.svg\" />", 
+                "", 
+                "<img src=\"ug-map-easter_island.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "k2C(Yth]0v", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "French Guiana", 
+                "Overseas department of France.", 
+                "Cayenne", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-french_guiana.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "L?BHEt4@}E", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Gibraltar", 
+                "Overseas territory of the United Kingdom.", 
+                "Gibraltar", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-gibraltar.svg\" />", 
+                "", 
+                "<img src=\"ug-map-gibraltar.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "QkI?BI[ma", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Guernsey", 
+                "Crown dependency of the United Kingdom.", 
+                "St. Peter Port", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-guernsey.svg\" />", 
+                "", 
+                "<img src=\"ug-map-guernsey.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "m)_7rh[Lpm", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Isle of Man", 
+                "Crown dependency of the United Kingdom.", 
+                "Douglas", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-isle_of_man.svg\" />", 
+                "", 
+                "<img src=\"ug-map-isle_of_man.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "i%-peAjWrs", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Jersey", 
+                "Crown dependency of the United Kingdom.", 
+                "Saint Helier", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-jersey.svg\" />", 
+                "", 
+                "<img src=\"ug-map-jersey.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "OU}Lz}9YKB", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kiribati", 
+                "", 
+                "South Tarawa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kiribati.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kiribati.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "KK@|*v&zH?", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Macau", 
+                "Special Administrative Region of China.", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-macau.svg\" />", 
+                "", 
+                "<img src=\"ug-map-macau.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "oo6GDjZ[ZJ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Madeira", 
+                "Autonomous region of Portugal.", 
+                "Funchal", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-madeira.svg\" />", 
+                "", 
+                "<img src=\"ug-map-madeira.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "cBwGt[yyI4", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Marshall Islands", 
+                "", 
+                "Majuro", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-marshall_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-marshall_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "pCfLLCwQh>", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Melilla", 
+                "Autonomous city of Spain", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-melilla.png\" />", 
+                "", 
+                "<img src=\"ug-map-melilla.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wLSmq*+&2{", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Montserrat", 
+                "Overseas territory of the United Kingdom.", 
+                "Brades", 
+                "Eruptions in 1997 destroyed the capital city of Plymouth, making Brades the de facto capital.", 
+                "", 
+                "<img src=\"ug-flag-montserrat.svg\" />", 
+                "", 
+                "<img src=\"ug-map-montserrat.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "xVXTs%(8_Z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Nauru", 
+                "", 
+                "Yaren", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-nauru.svg\" />", 
+                "", 
+                "<img src=\"ug-map-nauru.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "j9PA$2L.1z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "New Caledonia", 
+                "Overseas territory of France.", 
+                "Nouméa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-new_caledonia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-new_caledonia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "J=n5lSTV!A", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Niue", 
+                "", 
+                "Alofi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-niue.svg\" />", 
+                "", 
+                "<img src=\"ug-map-niue.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "fq6g>q{q/E", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Norfolk Island", 
+                "External territory of Australia.", 
+                "Kingston", 
+                "", 
+                "Oceania", 
+                "<img src=\"ug-flag-norfolk_island.svg\" />", 
+                "", 
+                "<img src=\"ug-map-norfolk_island.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "tLv;zCymUC", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Northern Cyprus", 
+                "State recognised only by Turkey and claimed by Cyprus.", 
+                "North Nicosia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-northern_cyprus.svg\" />", 
+                "", 
+                "<img src=\"ug-map-northern_cyprus.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "qoiQ]f9nl]", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Middle_East", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Saba", 
+                "Special municipality of the Netherlands.", 
+                "The Bottom", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-saba.svg\" />", 
+                "", 
+                "<img src=\"ug-map-saba.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "lh$DKy<1-:", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Saint Kitts and Nevis", 
+                "", 
+                "Basseterre", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-saint_kitts_and_nevis.svg\" />", 
+                "", 
+                "<img src=\"ug-map-saint_kitts_and_nevis.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gO=Iweaw1/", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Samoa", 
+                "", 
+                "Apia", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-samoa.svg\" />", 
+                "", 
+                "<img src=\"ug-map-samoa.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "I5oS~^(GpO", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Somaliland", 
+                "Independent state claimed by Somalia.", 
+                "Hargeisa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-somaliland.svg\" />", 
+                "", 
+                "<img src=\"ug-map-somaliland.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "MA,%:74AT5", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "South Sudan", 
+                "", 
+                "Juba", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-south_sudan.svg\" />", 
+                "", 
+                "<img src=\"ug-map-south_sudan.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "F$&4BQmhH+", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tuvalu", 
+                "", 
+                "Funafuti", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-tuvalu.svg\" />", 
+                "", 
+                "<img src=\"ug-map-tuvalu.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "J$hUXxC_RF", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "United States Virgin Islands", 
+                "Unincorporated territory of the United States.", 
+                "Charlotte Amalie", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-united_states_virgin_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-united_states_virgin_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "IP&gS=YCrc", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Pitcairn Islands", 
+                "Overseas territory of the United Kingdom.", 
+                "Adamstown", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-pitcairn_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-pitcairn_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "fn|_~A5%#V", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Åland Islands", 
+                "Autonomous region of Finland.", 
+                "Mariehamn", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-aland_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-aland_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gB.BY.ofZ^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Cocos (Keeling) Islands", 
+                "External territory of Australia.", 
+                "West Island", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-cocos_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-cocos_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "5G^26b_qv", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Southeast_Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Saint Helena", 
+                "Part of Saint Helena, Ascension and Tristan da Cunha, an overseas territory of the United Kingdom.", 
+                "Jamestown", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-saint_helena.png\" />", 
+                "", 
+                "<img src=\"ug-map-saint_helena.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "x/@vtQ!Jr_", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sint Eustatius", 
+                "Special municipality of the Netherlands.", 
+                "Oranjestad", 
+                "", 
+                "Special municipality", 
+                "<img src=\"ug-flag-sint_eustatius.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sint_eustatius.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "OI3&G*P|?)", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "South Ossetia", 
+                "Independent state claimed by Georgia.", 
+                "Tskhinvali", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-south_ossetia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-south_ossetia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "I(}#][{#{", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tokelau", 
+                "Dependent territory of New Zealand.", 
+                "Atafu", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-tokelau.svg\" />", 
+                "", 
+                "<img src=\"ug-map-tokelau.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "oQ|Edjm3,#", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "American Samoa", 
+                "Unincorporated territory of the United States.", 
+                "Pago Pago", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-american_samoa.png\" />", 
+                "", 
+                "<img src=\"ug-map-american_samoa.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "H`=/Bm|Kx$", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Northern Mariana Islands", 
+                "Unincorporated territory of the United States.", 
+                "Saipan", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-northern_mariana_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-northern_mariana_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "v-,e)hNAm|", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Aruba", 
+                "Constituent country of the Kingdom of the Netherlands.", 
+                "Oranjestad", 
+                "", 
+                "Constituent country", 
+                "<img src=\"ug-flag-aruba.svg\" />", 
+                "", 
+                "<img src=\"ug-map-aruba.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "m,7`N)QOMY", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Abkhazia", 
+                "Independent state claimed by Georgia.", 
+                "Sukhumi", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-abkhazia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-abkhazia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "K!-D;j%k*=", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sint Maarten", 
+                "Constituent country of the Kingdom of the Netherlands.", 
+                "Philipsburg", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sint_maarten.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sint_maarten.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sX!g[>x^=&", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Artsakh", 
+                "Independent state claimed by Azerbaijan, formerly known as Nagorno-Karabakh.", 
+                "Stepanakert", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-artsakh.svg\" />", 
+                "", 
+                "<img src=\"ug-map-artsakh.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "FcN04Un!.9", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tonga", 
+                "", 
+                "Nuku'alofa", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-tonga.svg\" />", 
+                "", 
+                "<img src=\"ug-map-tonga.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "zH>>&xIT)5", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Transnistria", 
+                "Independent state claimed by Moldova.", 
+                "Tiraspol", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-transnistria.svg\" />", 
+                "", 
+                "<img src=\"ug-map-transnistria.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "tT_.AxEK${", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe", 
+                "UG::Sovereign_State"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sardinia", 
+                "Autonomous region of Italy.", 
+                "Cagliari", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sardinia.svg\" />", 
+                "", 
+                "<img src=\"ug-map-sardinia.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f^AEc<=VM=", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Kaliningrad Oblast", 
+                "State (oblast) of the Russian Federation.", 
+                "Kaliningrad", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-kaliningrad_oblast.svg\" />", 
+                "", 
+                "<img src=\"ug-map-kaliningrad_oblast.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "v6w,S7a}t,", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Martinique", 
+                "Overseas department of France.", 
+                "Fort-de-France", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-martinique.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "IKQ>Co,rC5", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::Caribbean"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Java", 
+                "Island of Indonesia.", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-java.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sCLh-9,Ezq", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Corsica", 
+                "Region of France.", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-corsica.svg\" />", 
+                "", 
+                "<img src=\"ug-map-corsica.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "brWOI^@t[<", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "European Union", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-european_union.svg\" />", 
+                "", 
+                "<img src=\"ug-map-european_union.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "O=Bu:;JPQr", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Gulf of Mexico", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-gulf_of_mexico.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "bEx*i=Yx!1", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Philippine Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-philippine_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "m|!,4+W3Ni", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Southern Ocean", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-southern_ocean.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "uTmiz2}/pT", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Gulf of Thailand", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-gulf_of_thailand.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Or4YWW,K8?", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Micronesia", 
+                "Subregion of Oceania comprising thousands of small islands in the western Pacific Ocean.", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-micronesia.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "s76ok%QfH)", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Pacific Ocean", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-pacific_ocean.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "P(6!oHZFU8", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Atlantic Ocean", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-atlantic_ocean.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "PLkFoWchK*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Indian Ocean", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-indian_ocean.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "t?x9Zuu#Bd", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Arctic Ocean", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-arctic_ocean.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "v^G3nqUz?z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Hudson Bay", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-hudson_bay.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "I[T8&axP@^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Labrador Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-labrador_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "x%+l|f2>c+", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "White Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-white_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "j#P8*t?H%6", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Denmark Strait", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-denmark_strait.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "C+,nhzHAU`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Norwegian Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-norwegian_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "d]4(DUsL[F", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Baltic Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-baltic_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "v+QJJz`:fG", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Celtic Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-celtic_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "j.)1kPOjCA", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "English Channel", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-english_channel.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "o6ptXpUi8*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Adriatic Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-adriatic_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "OsBGM3O]J^", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bay of Biscay", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-bay_of_biscay.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "HX[~E&OnOJ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Black Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-black_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "yDSx%+|?Sc", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Aegean Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-aegean_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "OqFMTBUfE#", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Balkan Peninsula", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-balkan_peninsula.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wmzbfOXS!-", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Caspian Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-caspian_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "o|%-]-Rq0a", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mediterranean Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-mediterranean_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "C%X+Zc;=o_", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "East Siberian Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-east_siberian_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "K(lKfDd9|M", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bering Strait", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-bering_strait.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "f$W_-Zg_Z*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Arabian Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-arabian_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "p?sq-P?D5e", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Red Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-red_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "F=3m?A}[c5", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Dead Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-dead_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "J><D,x;Pf", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Bay of Bengal", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-bay_of_bengal.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "cp;B.6kX(`", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sea of Japan", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-sea_of_japan.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "va6{fKXhmD", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Yellow Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-yellow_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "E93FJ+-35J", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Coral Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-coral_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "x9+0h:q[jK", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "South China Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-south_china_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Q,p<3jZ6#", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Tasman Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-tasman_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "pevrEWUWOC", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Gulf of Carpenteria", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-gulf_of_carpenteria.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "z(awq_%Uq@", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Aral Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-aral_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "pl7Pu<VH#]", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Persian Gulf", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-persian_gulf.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "mjC,dF~*AN", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Caribbean Sea", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-caribbean_sea.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "wPIR_|6_;N", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Gulf of California", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-gulf_of_california.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "yrYU_}B1i>", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Polynesia", 
+                "Subregion of Oceania comprising thousands of small islands in the central and southern Pacific Ocean.", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-polynesia.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "g&|jqw)$Q*", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Melanesia", 
+                "Subregion of Oceania, which includes the four countries of&nbsp;Vanuatu, the Solomon Islands, Fiji, and Papua New Guinea.", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-melanesia.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "oo;B=8Z|vZ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceania"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Scandinavia", 
+                "Historical and cultural region in Northern Europe, which includes the countries of Denmark, Norway and Sweden, and sometimes Finland and Iceland.", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-scandinavia.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "HH:g4uFP/p", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sea of Galilee", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-sea_of_galilee.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "B?pB&V|12f", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Oceans+Seas"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sumatra", 
+                "Island of&nbsp;Indonesia.", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-sumatra.jpg\" />"
+            ], 
+            "flags": 0, 
+            "guid": "Q4eW<V.ct~", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Asia"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mount Athos", 
+                "Autonomous orthodox monastic state in northeastern Greece, also known as the Holy Mountain.", 
+                "Karyes", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-mount_athos.png\" />", 
+                "", 
+                ""
+            ], 
+            "flags": 0, 
+            "guid": "lHbA@.#q5Z", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Sicily", 
+                "Autonomous region of Italy.", 
+                "Palermo", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-sicily.svg\" />", 
+                "", 
+                ""
+            ], 
+            "flags": 0, 
+            "guid": "hByEv=a/LF", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Europe"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Mayotte", 
+                "Overseas department of France.", 
+                "Mamoudzou", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-mayotte.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "gcn!)QjsJz", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Réunion", 
+                "Overseas department of France.", 
+                "Saint-Denis", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-reunion.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "b%^f6jbs<P", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "British Indian Ocean Territory", 
+                "Overseas territory of the United Kingdom.", 
+                "Camp Justice", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-british_indian_ocean_territory.svg\" />", 
+                "", 
+                "<img src=\"ug-map-british_indian_ocean_territory.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "KP`e4ldjei", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Africa"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Falkland Islands", 
+                "Overseas territory of the United Kingdom.", 
+                "Stanley", 
+                "", 
+                "", 
+                "<img src=\"ug-flag-falkland_islands.svg\" />", 
+                "", 
+                "<img src=\"ug-map-falkland_islands.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "OEwUJEuH#P", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::America", 
+                "UG::South_America"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Europe", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-europe.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "sj[wKwcvz1", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "North America", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-north_america.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "tv0GfZ;pfe", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "South America", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-south_america.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "er4q.eH&TN", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Asia", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-asia.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "PvfQ$HX-LJ", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Africa", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-africa.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "hW89qG0/7|", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Australia (Oceania)", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-oceania.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "IJZ-p||,>g", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }, 
+        {
+            "__type__": "Note", 
+            "data": "", 
+            "fields": [
+                "Antarctica", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "", 
+                "<img src=\"ug-map-antarctica.png\" />"
+            ], 
+            "flags": 0, 
+            "guid": "ir9d(k*l#o", 
+            "note_model_uuid": "9245964f-cc9b-11e6-9699-a0481cc15658", 
+            "tags": [
+                "UG::Continents"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Preparing for issue #52. Had to duplicate and rename the note type, export the English deck as `txt` and re-import it into a new deck called _Ultimate Geography (DE)_.