### PR TITLE
Capital of Kazakhstan renamed from Astana to Nur-Sultan. Fixes #97.

### DIFF
--- a/src/data.csv
+++ b/src/data.csv
@@ -54,7 +54,7 @@ fGeuUP`?$F,Ukraine,Ukraine,,,Kiev,Kiew,,,,,"<img src=""ug-flag-ukraine.svg"" />"
 kW{?TY+Qy@,"Vatican City",Vatikanstadt,,,"Vatican City",Vatikanstadt,,,,,"<img src=""ug-flag-vatican_city.svg"" />",,,"<img src=""ug-map-vatican_city.png"" />","UG::Europe UG::Sovereign_State"
 aoo{E3^%kC,Armenia,Armenien,,,Yerevan,Jerewan,,,,,"<img src=""ug-flag-armenia.svg"" />",,,"<img src=""ug-map-armenia.png"" />","UG::Europe UG::Sovereign_State"
 iWJ];?5|N/,Cyprus,"Republik Zypern",,,Nicosia,Nikosia,,,,,"<img src=""ug-flag-cyprus.svg"" />",,,"<img src=""ug-map-cyprus.png"" />","UG::Asia UG::European_Union UG::Middle_East UG::Sovereign_State"
-gMdH0b17|`,Kazakhstan,Kasachstan,,,Astana,Nursultan,"officially Nur-Sultan.","Auch Nur-Sultan. Früher Astana.",,,"<img src=""ug-flag-kazakhstan.svg"" />",,,"<img src=""ug-map-kazakhstan.png"" />",UG::Asia UG::Sovereign_State
+gMdH0b17|`,Kazakhstan,Kasachstan,,,Nur-Sultan,Nursultan,"Formerly known as Astana, it was renamed Nur-Sultan in March 2019.","Auch Nur-Sultan. Früher Astana.",,,"<img src=""ug-flag-kazakhstan.svg"" />",,,"<img src=""ug-map-kazakhstan.png"" />",UG::Asia UG::Sovereign_State
 hmmcO+mVAb,Egypt,Ägypten,,,Cairo,Kairo,,,,,"<img src=""ug-flag-egypt.svg"" />","Yemen (no emblem)","Jemen (kein Wappen)","<img src=""ug-map-egypt.png"" />","UG::Africa UG::Middle_East UG::Sovereign_State"
 ~PH%PYbY:P,Algeria,Algerien,,,Algiers,Algier,,,,,"<img src=""ug-flag-algeria.svg"" />",,,"<img src=""ug-map-algeria.png"" />","UG::Africa UG::Sovereign_State"
 mZ-*)8}IxB,Angola,Angola,,,Luanda,Luanda,,,,,"<img src=""ug-flag-angola.svg"" />",,,"<img src=""ug-map-angola.png"" />","UG::Africa UG::Sovereign_State"


### PR DESCRIPTION
This was fixed in #89 for German, but not for the default language.