### PR TITLE
Mention Anki's filtered deck feature in deck description and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 **Geography flashcard deck for [Anki](http://ankisrs.net/)** featuring:
 
 - the world's **[206 sovereign states](https://en.wikipedia.org/wiki/List_of_sovereign_states)** (824 cards)
-- **67 overseas territories** and dependent areas (227 cards)
+- **67 overseas territories** and dependent areas (224 cards)
 - **39 oceans and seas** (39 cards, maps only)
 - **7 continents** (7 cards, maps only)
-- for a total of **319 unique notes**, **1096 cards**, **260 flags** and **317 maps**.
+- for a total of **319 unique notes**, **1094 cards**, **260 flags** and **317 maps**.
 
 | Flag - Country | Map - Country |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | --- | --- |
 | ![sample-1](https://cloud.githubusercontent.com/assets/2936402/21575807/3ac6ebec-cf6e-11e6-849a-19544d5dccf5.png) | ![sample-2](https://cloud.githubusercontent.com/assets/2936402/21575809/3ac77b7a-cf6e-11e6-8d72-76f4d3e21de8.png) |
 
-The deck is available in **English** and **German**. An **extended version** is also available in both languages with the following note templates: _Country - Flag_ and _Country - Map_.
+The deck is available in **English** and **German**. An **extended version** is also available in both languages with the following additional note templates: _Country - Flag_ and _Country - Map_. Use Anki's [filtered deck feature](#custom-study) to study only a specific type of cards (e.g. map to country) or area of the world (e.g. Europe).
 
 The flags and most of the maps are sourced from [Wikimedia Commons](https://commons.wikimedia.org/). They are provided as SVG or PNG and optimised for smaller file size. Some legacy JPEG maps from the original deck (cf. [Background](#background) section below) are still present, but are [marked for replacement](https://github.com/axelboc/anki-ultimate-geography/issues/1#issuecomment-275280721).
 

--- a/src/desc.html
+++ b/src/desc.html
@@ -9,7 +9,7 @@
 - <b>7 continents</b> (7 cards, maps only)
 - for a total of <b>319 unique notes</b>, <b>1097 cards</b>, <b>260 flags</b> and <b>317 maps</b>.
 
-The deck is available in <b>English</b> and <b>German</b>. An <b>extended version</b> is also available in both languages.
+The deck is available in <b>English</b> and <b>German</b>. An <b>extended version</b> is also available in both languages. Use Anki's <a href="https://github.com/axelboc/anki-ultimate-geography#custom-study">filtered deck feature</a> to study only a specific type of cards (e.g. map to country) or area of the world (e.g. Europe).
 
 The flags and maps are sourced from <a href="https://commons.wikimedia.org/">Wikimedia Commons</a> and optimised for smaller file size. To help with memorisation and provide context while learning, some notes include extra information such as similar flags, governance information, alternative country names, etc.
 


### PR DESCRIPTION
The first ever negative comment on [AnkiWeb](https://ankiweb.net/shared/info/2109889812) asks how to study only map to country cards. I figure this means that Anki's filtered deck feature is not known to all and should be mentioned in the deck's description.