### PR TITLE
Fix source for Antigua and Barbuda

### DIFF
--- a/sources.csv
+++ b/sources.csv
@@ -272,7 +272,7 @@ ug-map-andorra.png,https://commons.wikimedia.org/wiki/File:Andorra_in_its_region
 ug-map-angola.png,https://commons.wikimedia.org/wiki/File:Angola_in_its_region.svg,CC BY-SA 3.0,
 ug-map-anguilla.png,https://commons.wikimedia.org/wiki/File:Anguilla_in_its_region.svg,CC BY-SA 3.0,
 ug-map-antarctica.png,https://commons.wikimedia.org/wiki/File:Antarctica_in_the_world_(red)_(W3).svg,CC BY-SA 3.0,
-ug-map-antigua_and_barbuda.png,https://commons.wikimedia.org/wiki/File:Antigua_and_Barbuda_in_its_region.svg,CC BY-SA 3.0,
+ug-map-antigua_and_barbuda.png,https://commons.wikimedia.org/wiki/File:Antigua_and_Barbuda_in_its_region_(zoomed).svg,CC BY-SA 3.0,
 ug-map-arabian_sea.jpg,?,,
 ug-map-aral_sea.jpg,?,,
 ug-map-arctic_ocean.png,https://commons.wikimedia.org/wiki/File:Arctic_Ocean.png,PD,


### PR DESCRIPTION
I had provided the wrong source for the map of Antigua and Barbuda (one without the zoom-box, rather than the correct one, with the zoom-box).

FWIW, I think that there should be no more such errors: when mass-compiling the sources for the maps, a couple of weeks ago, I had been slightly less careful in ensuring the source corresponded to our version (just looking whether the source looked "about right", rather than comparing the source with our copy, side-by-side) for the "A"s, before realising at Azerbaijan that I couldn't be sure that I was getting the source version with the correct "stripes" (disputed territories), and switching to the less error-prone method (comparing side-by-side). (I've now compared all of the "A"s to make sure that no more mistakes had crept in among them.)

Sorry for the error!