### PR TITLE
Add emoji to templates as an answer type hint

### DIFF
--- a/src/templates/Country - Capital.html
+++ b/src/templates/Country - Capital.html
@@ -5,7 +5,7 @@
   <hr>
 
   <div class="type">Capital</div>
-  <div class="value">?</div>
+  <div class="value">🏙️?</div>
 {{/Capital}}
 
 --

--- a/src/templates/Country - Flag.html
+++ b/src/templates/Country - Flag.html
@@ -5,7 +5,7 @@
   <hr>
 
   <div class="type">Flag</div>
-  <div class="value">?</div>
+  <div class="value">🏳️?</div>
 {{/Flag}}
 
 --

--- a/src/templates/Country - Map.html
+++ b/src/templates/Country - Map.html
@@ -5,7 +5,7 @@
   <hr>
 
   <div class="type">Location</div>
-  <div class="value">?</div>
+  <div class="value">📍?</div>
 {{/Map}}
 
 --


### PR DESCRIPTION
To make it easier to see which type of answer is expected, I added emoji in front of the question marks. With one exception: Countries; they're such an abstract notion that it's hard to avoid something which conflicts with the other emoji.

The hint emoji I chose are:

- **Capital**: 🏙️ [Cityscape](https://emojipedia.org/cityscape/). Also considered other emoji of houses and buildings, but I think this one is more likely to give the right idea. Not all capitals look like this, but what are you gonna do.
- **Location**: 📍 [Round pushpin](https://emojipedia.org/round-pushpin/). Chosen because the map pin is associated with the concept of location in map software. Also considered the [world map](https://emojipedia.org/world-map/) emoji, but it was to similar to the cityscape emoji on Apple platforms.
- **Flag**: 🏳️ [White flag](https://emojipedia.org/waving-white-flag/). Also considered a black flag, but I just think of white as more of a blank slate than black.


Hope you like the idea!

Solves #152 