### PR TITLE
Capital -> Country Small Template change

### DIFF
--- a/src/templates/Capital - Country.html
+++ b/src/templates/Capital - Country.html
@@ -17,4 +17,5 @@
 
 <div class="type">Capital</div>
 <div class="value">{{Capital}}</div>
+{{#Capital hint}}<div class="info">Hint: {{Capital hint}}</div>{{/Capital hint}}
 {{#Capital info}}<div class="info">{{Capital info}}</div>{{/Capital info}}


### PR DESCRIPTION
###### [Very small tiny insignificant change]

![image](https://user-images.githubusercontent.com/1471350/67614988-8a74b380-f7c6-11e9-98bb-3642dc9801ad.png)

I noticed recently that the "Capital hint" field is removed from the card when the back is shown. As far as I can see Capital -> Country is the only card type which removes info on the back. As a rule, Cloze templates do not remove data, the reveal it. Or so I believe :sweat_smile: 


I personally would like it to stay :smile: 

Interesting side note: I thought "what if the Capital Hint and the Capital Info fields get mixed up to the user?" Well *there are no cards with both a Capital Hint and a Capital Info* as of now :open_mouth: but regardless, if there was it'd look like this:

![Screenshot_20191026_080451](https://user-images.githubusercontent.com/1471350/67615047-6ebddd00-f7c7-11e9-9721-6ee560604e85.png)


The div separates them well enough, in my opinion :smile: 
