### PR TITLE
Add CI workflow to check integrity

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -1,0 +1,35 @@
+name: Integrity check
+
+on: [push]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Build decks
+      run: composer build
+
+  index:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Index data.csv
+      run: composer index
+
+    - name: Check diff
+      run: git diff-index --quiet HEAD -- || echo "You need to run `composer index`"

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,7 @@
 {
+  "name": "axelboc/anki-ultimate-geography",
+  "description": "Geography flashcard deck for Anki",
+  "license": "Unlicense",
   "repositories": [
     {
       "type": "vcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32d532eea3c2da4296962b1e5937b253",
+    "content-hash": "8bef582dd9108547bd5b8595533303a8",
     "packages": [
         {
             "name": "docopt/docopt",
@@ -219,16 +219,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -240,7 +240,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -257,12 +257,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                },
-                {
                     "name": "Gert de Pagter",
                     "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -273,7 +273,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Thought I'd give GitHub Action a try... If it's too annoying, we can remove it.

The workflow is composed of two jobs:
- one that checks `composer.json` and builds the decks;
- one that runs `composer index` and fails if there are uncommited changes -- that is, if escaping quotes were added/removed to `data.csv`.