### PR TITLE
Add styling for Anki's and Anki Mobile's built-in dark mode

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -42,3 +42,7 @@
 hr {
   margin: 1.5em 0;
 }
+
+.nightMode .info, .nightMode .type {
+  color: #ccc;
+}


### PR DESCRIPTION
This deals with the issue of the info (and "type") text being displayed as dark grey on black.

This is not necessary for Ankidroid, since Ankidroid dark mode automatically inverts all text colours, but doesn't hurt either.

Once #156 is resolved, one could consider adding a selector for `.night_mode`, for the popular dark-mode add-on. (Until then there are more serious (breaking) issues with the combination of ultimate geography with the add-on.)