### PR TITLE
Add link to issue reference for convenience in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Anki requires each note to have a unique identifier. When you add a note to the 
 
 ### Quotes normalisation
 
-Anki Deck Manager has a very specific way of wrapping fields with double quotes  in `data.csv` to escape special characters (cf. #129). Whether you edit the file by hand or through an editor, chances are you won't end up with double quotes in the same places. If you commit the file as is, the diff will be cluttered with changes that have nothing to do with your edits. To avoid this, run `composer index` before commiting your changes. This command has the side effect of normalising the escaping of fields in the entire file.
+Anki Deck Manager has a very specific way of wrapping fields with double quotes  in `data.csv` to escape special characters (cf. [#129](https://github.com/axelboc/anki-ultimate-geography/issues/129)). Whether you edit the file by hand or through an editor, chances are you won't end up with double quotes in the same places. If you commit the file as is, the diff will be cluttered with changes that have nothing to do with your edits. To avoid this, run `composer index` before commiting your changes. This command has the side effect of normalising the escaping of fields in the entire file.
 
 ## Maintainer's guide
 


### PR DESCRIPTION
GitHub doesn't automatically link to issues or pull requests when using the #N format which works in comments.

This commit is inspired by the discussion [here](https://github.com/axelboc/anki-ultimate-geography/issues/161#issuecomment-562604966) which shows that the description of quotes normalisation in [`CONTRIBUTING.md`](https://github.com/axelboc/anki-ultimate-geography/blob/master/CONTRIBUTING.md#quotes-normalisation) might not be entirely clear for somebody new to the potential problem.

Unfortunately (?), to me it does seem completely clear. I think it might be a topic that is obvious once you encounter the issue, but non-obvious before then.

I can't really think of how to improve the section without expanding it excessively, so at least I've made access to the expanded discussion in the relevant issue (#129) easier.