### PR TITLE
"Flag" and "Map" placeholder hints

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -37,6 +37,18 @@
   display: none;
 }
 
+.image__placeholder {
+  color: #333;
+  height: auto; /* Required for Chromium */
+  max-width: 100%;
+}
+
+.image__placeholder path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1;
+}
+
 .image img {
   box-shadow: 0 1px 4px 1px rgba(0, 0, 0, .2);
 }
@@ -53,6 +65,11 @@ hr {
   margin: 1.5em 0;
 }
 
-.nightMode .info, .nightMode .type {
+.night_mode .info,
+.night_mode .type,
+.night_mode .image__placeholder,
+.nightMode .info,
+.nightMode .type,
+.nightMode .image__placeholder {
   color: #ccc;
 }

--- a/src/templates/Country - Flag.html
+++ b/src/templates/Country - Flag.html
@@ -5,7 +5,17 @@
   <hr>
 
   <div class="type">Flag</div>
-  <div class="value">?</div>
+  <div class="image">
+    <svg
+      class="image__placeholder"
+      xmlns="http://www.w3.org/2000/svg"
+      width="417"
+      height="250"
+	  viewBox="0 0 417 250"
+    >
+      <path d="m2 26s45-24 129-24c86 0 146 25 210 25 64 0 74-10 74-10v218s-25 13-83 13-146-25-206-25c-60 0-123 19-123 19z" />
+    </svg>
+  </div>
 {{/Flag}}
 
 --

--- a/src/templates/Country - Map.html
+++ b/src/templates/Country - Map.html
@@ -4,7 +4,17 @@
   <hr>
 
   <div class="type">Location</div>
-  <div class="value">?</div>
+  <div class="image">
+    <svg
+      class="image__placeholder"
+      xmlns="http://www.w3.org/2000/svg"
+      width="500"
+      height="308"
+	  viewBox="0 0 500 308"
+    >
+      <path d="m154 2s-151 44-152 152c-1 108 152 152 152 152h193s151-44 151-152c1-107-151-152-151-152z" />
+    </svg>
+  </div>
 {{/Map}}
 
 --


### PR DESCRIPTION
Fix #152 

Someone with an iPhone ought to double-check dark mode still works properly with this, as I changed code from PR #173 to fix an AnkiDroid regression introduced with fb7f4e8.

In addition, note I used https://commons.wikimedia.org/wiki/File:World_location_map_(W3).svg to get a proper outline of a Winkel III projection as found in this deck's inset maps, but don't think it's needed in `sources.csv` as I remade the file by hand to optimize size (original outline was 700 nodes, I remade by hand with just 6 nodes).

Lastly, I just noticed in [CONTRIBUTING.md](https://github.com/axelboc/anki-ultimate-geography/blob/master/CONTRIBUTING.md) that maps get a width of 500px, unlike flags which get a height of 250px. I will rectify this in a bit.