### PR TITLE
Refactor class names and tidy styles

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -36,6 +36,8 @@
 }
 
 .value > img {
+  max-width: 100%;
+  height: auto;
   box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.2);
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,18 +1,26 @@
 .card {
+  padding: 1em 0;
   background-color: white;
   color: black;
   font-family: Verdana;
   font-size: 16px;
-  padding: 1em 0;
   text-align: center;
 }
 
 .type {
+  margin-bottom: 0.25em;
   color: #333;
   font-size: 70%;
   font-weight: bold;
-  margin-bottom: .25em;
   text-transform: uppercase;
+}
+
+.info {
+  max-width: 30em;
+  margin: 0.75em auto;
+  color: #333;
+  font-size: 90%;
+  font-style: italic;
 }
 
 .value {
@@ -23,53 +31,51 @@
   margin-top: 1em;
 }
 
-.image {
-  margin-top: .75em
+.value--image {
+  margin-top: 0.75em;
 }
 
-/* Some flags (e.g. Guam's) contain identifying words that can give away the answer */
-/* Card backs always show the unmodified image(s) */
-/* If a blurred image(s) is available, card front shows that instead */
-.image--front > img[src*="-blur"] + img {
-  display: none;
+.value > img {
+  box-shadow: 0 1px 4px 1px rgba(0, 0, 0, 0.2);
 }
-.image--back > img[src*="-blur"] {
+
+/**
+ * Some flags (e.g. Guam's) contain identifying words that can give away the answer.
+ * If a blurred version is available, show it on the front but not on the back.
+ */
+.value--front > img[src*="-blur"] + img {
   display: none;
 }
 
-.image__placeholder {
-  color: #333;
-  height: auto; /* Required for Chromium */
+.value--back > img[src*="-blur"] {
+  display: none;
+}
+
+/**
+ * Placeholder SVG to hint at the type of answer that is expected.
+ * Used on "Country - Flag" and "Country - Map" templates.
+ */
+.placeholder {
   max-width: 100%;
+  height: auto;
+  color: #333;
 }
 
-.image__placeholder path {
+.placeholder > path {
   fill: none;
   stroke: currentColor;
   stroke-width: 1;
 }
 
-.image img {
-  box-shadow: 0 1px 4px 1px rgba(0, 0, 0, .2);
-}
-
-.info {
-  color: #333;
-  font-size: 90%;
-  font-style: italic;
-  margin: .75em auto;
-  max-width: 30em;
+.night_mode .info,
+.night_mode .type,
+.night_mode .placeholder,
+.nightMode .info,
+.nightMode .type,
+.nightMode .placeholder {
+  color: #ccc;
 }
 
 hr {
   margin: 1.5em 0;
-}
-
-.night_mode .info,
-.night_mode .type,
-.night_mode .image__placeholder,
-.nightMode .info,
-.nightMode .type,
-.nightMode .image__placeholder {
-  color: #ccc;
 }

--- a/src/templates/Country - Flag.html
+++ b/src/templates/Country - Flag.html
@@ -5,13 +5,13 @@
   <hr>
 
   <div class="type">Flag</div>
-  <div class="image">
+  <div class="value value--image">
     <svg
-      class="image__placeholder"
+      class="placeholder"
       xmlns="http://www.w3.org/2000/svg"
       width="417"
       height="250"
-	  viewBox="0 0 417 250"
+      viewBox="0 0 417 250"
     >
       <path d="m2 26s45-24 129-24c86 0 146 25 210 25 64 0 74-10 74-10v218s-25 13-83 13-146-25-206-25c-60 0-123 19-123 19z" />
     </svg>
@@ -26,5 +26,5 @@
 <hr id=answer>
 
 <div class="type">Flag</div>
-<div class="image image--back">{{Flag}}</div>
+<div class="value value--image value--back">{{Flag}}</div>
 {{#Flag similarity}}<div class="info">Flag similar to {{Flag similarity}}.</div>{{/Flag similarity}}

--- a/src/templates/Country - Map.html
+++ b/src/templates/Country - Map.html
@@ -4,13 +4,13 @@
   <hr>
 
   <div class="type">Location</div>
-  <div class="image">
+  <div class="value value--image">
     <svg
-      class="image__placeholder"
+      class="placeholder"
       xmlns="http://www.w3.org/2000/svg"
       width="500"
       height="308"
-	  viewBox="0 0 500 308"
+      viewBox="0 0 500 308"
     >
       <path d="m154 2s-151 44-152 152c-1 108 152 152 152 152h193s151-44 151-152c1-107-151-152-151-152z" />
     </svg>
@@ -25,4 +25,4 @@
 <hr id=answer>
 
 <div class="type">Location</div>
-<div class="image">{{Map}}</div>
+<div class="value value--image">{{Map}}</div>

--- a/src/templates/Flag - Country.html
+++ b/src/templates/Flag - Country.html
@@ -4,7 +4,7 @@
   <hr>
 
   <div class="type">Flag</div>
-  <div class="image image--front">{{Flag}}</div>
+  <div class="value value--image value--front">{{Flag}}</div>
 {{/Flag}}
 
 --
@@ -15,5 +15,5 @@
 <hr>
 
 <div class="type">Flag</div>
-<div class="image image--back">{{Flag}}</div>
+<div class="value value--image value--back">{{Flag}}</div>
 {{#Flag similarity}}<div class="info">Flag similar to {{Flag similarity}}.</div>{{/Flag similarity}}

--- a/src/templates/Map - Country.html
+++ b/src/templates/Map - Country.html
@@ -4,7 +4,7 @@
   <hr>
 
   <div class="type">Location</div>
-  <div class="image">{{Map}}</div>
+  <div class="value value--image">{{Map}}</div>
 {{/Map}}
 
 --
@@ -15,4 +15,4 @@
 <hr>
 
 <div class="type">Location</div>
-<div class="image">{{Map}}</div>
+<div class="value value--image">{{Map}}</div>


### PR DESCRIPTION
Fixes #270

- Replace class `image` with classes `value value--image`.
- Rename `image__front` and `image__back` to `value__front` and `value__back`.
- Rename `image__placeholder` to `placeholder` for simplicity.
- Review comments in CSS and add more.
- Reorder CSS properties.
- Use direct descendant selector `>` where possible.
- Fix indentation in HTML to use spaces.
- Make images properly responsive with `max-width: 100%` and `height: auto` - not sure how this was working before 🤷 