### PR TITLE
Add light shadow in night mode

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -84,6 +84,15 @@
   color: #ccc;
 }
 
+/**
+ * Apply shadow to images, to bring out black areas on flags, in night
+   mode.
+ */
+.nightMode .value > img:not([src*="-nobox"]),
+.night_mode .value > img:not([src*="-nobox"]) {
+  box-shadow: 0 1px 4px 1px rgba(202, 202, 202, 0.2);
+}
+
 hr {
   margin: 1.5em 0;
 }


### PR DESCRIPTION
Fix #277.

I suggest #ccc (202,202,202) rather than pure white, since pure white looked slightly too glowy with Ankidroid's "dark" theme (surprisingly not the fully "black" one). However, for simplicity pure white (255, 255, 255) might be preferable.

I think that both #ccc and #fff are sufficient to "delineate" all flags, in black mode, at least if screen brightness is not too low (especially Uganda is a bit hit-and-miss particularly at low brightness, but the problem is present with both pure white and light grey to almost the same extent).

I'm not 100 % sure where to position the ruleset — as part of the "night mode group" or the "shadow group"?

### Screenshots

<details>
<summary>Some screenshots on Ankidroid</summary>

They're quite large area-wise, since otherwise the shadow becomes invisible.

"Dark" theme on Ankidroid

![Dark theme](https://user-images.githubusercontent.com/16461345/79015318-cf21ba80-7b6c-11ea-8ebe-31e528818664.jpg)

"Black" theme on Ankidroid

![Black theme](https://user-images.githubusercontent.com/16461345/79015343-dba61300-7b6c-11ea-9656-37bbf31e885c.jpg)

Without shadow on Ankidroid (with "black" theme)

![No shadow](https://user-images.githubusercontent.com/16461345/79015421-f7111e00-7b6c-11ea-8a71-5a07e4111386.jpg)

I'm not including more screenshots, since appearance varies considerably depending on screen brightness.

</details>

I've also tested on Anki Desktop and iOS (old version — 2.0.48).