### PR TITLE
Improve night mode glow/shadow of flags

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -90,7 +90,7 @@
  */
 .nightMode .value > img:not([src*="-nobox"]),
 .night_mode .value > img:not([src*="-nobox"]) {
-  box-shadow: 0 1px 4px 1px rgba(202, 202, 202, 0.2);
+  box-shadow: 0 0 4px 1px rgba(54, 54, 54, 0.9);
 }
 
 hr {


### PR DESCRIPTION
Implement @ukanuk's suggestions, resolving the problem with the glow's asymmetry, and its unnecessary visibility on a grey background.

I'm making the PR to get one step closer to fixing this, but @ukanuk, @axelboc and anyone else please feel free to tear it apart.