### PR TITLE
Remove outdated information in LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -45,6 +45,4 @@ The sources and licenses of the flags (`ug-flag-...`) and maps (`ug-map-...`) in
 
 `sources.csv` references only the licenses of the files themselves. Some flags, like the [European Union flag](https://www.coe.int/en/web/about-us/the-european-flag#column-5), may come with additional copyright retrictions.
 
-A question mark in the _Source_ column indicates that the source and license of an image are unknown. Effort is being made to replace such images (cf. issue #1).
-
 All images have been optimised, resized and/or converted to reduce file size. Any further modifications are listed in the  _Modifications_ column.


### PR DESCRIPTION
All images are now properly sourced.

I don't think that we'll ever want to add images of dubious provenance, so we don't need the removed sentence.

(I accidentally noticed, now — we've had only properly sourced images for a while now.)

Also, hooray on the release! :) Thanks for doing it! You didn't mention yourself, in the release notes, but your care, guidance and attention to detail are essential for the well-being of the deck!