### PR TITLE
Generate Guids Again

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-brain-brew = "0.3.1"
+brain-brew = "==0.3.2"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "539dc23cd59cc03977ef60a723fb7d8f97022510ac5675f3f33eb69f5d0b31d4"
+            "sha256": "a654fd645955af5870dbeabbb98f02060f0a402437bd0faf21aec968eaf4f4d0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "brain-brew": {
             "hashes": [
-                "sha256:7a52a6eff571f69d7787882f401e6a70bcabb76b2eae3c8e1d247d811d6cb94e",
-                "sha256:9a07e1d9d651f589cc383f143b24210f8225474bc34f26e090521fb36ef4fb2e"
+                "sha256:453d03b45bda7a51bffd96b127d2333426caed4431098f0277e79569f901e55f",
+                "sha256:780ddc98e6a006de687fe133a7406df5c7e91df5761e8e9f5374f46e04c4e73b"
             ],
             "index": "pypi",
-            "version": "==0.3.1"
+            "version": "==0.3.2"
         },
         "pyyaml": {
             "hashes": [

--- a/recipes/source_to_anki.yaml
+++ b/recipes/source_to_anki.yaml
@@ -1,3 +1,16 @@
+- generate_guids_in_csv:
+    source: src/data/guid.csv
+    columns:
+      - guid
+      - guid:de
+      - guid:es
+      - guid:fr
+      - guid:nb
+      - guid:cs
+      - guid:ru
+      - guid:nl
+      - guid:sv
+
 - build_parts:
   - note_model_templates_from_html:
       - part_id: Country - Capital

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Brain-Brew==0.3.1
+Brain-Brew==0.3.2
 PyYAML==5.3.1
 ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.2


### PR DESCRIPTION
Update to [Brain Brew 0.3.2](https://github.com/ohare93/brain-brew/pull/22) which adds a new `generate_guids_in_csv` task, as stated in #396. 

Tested and it works like a charm for me :+1: 