### PR TITLE
[DE] Change from Weißrussland to Belarus

### DIFF
--- a/src/data/country.csv
+++ b/src/data/country.csv
@@ -14,7 +14,7 @@ Albania,Albanien,Albania,Albanie,Albania,Albánie,Албания,Albanië,Albani
 Andorra,Andorra,Andorra,Andorre,Andorra,Andorra,Андорра,Andorra,Andorra
 Austria,Österreich,Austria,Autriche,Østerrike,Rakousko,Австрия,Oostenrijk,Österrike
 Azerbaijan,Aserbaidschan,Azerbaiyán,Azerbaïdjan,Aserbajdsjan,Ázerbájdžán,Азербайджан,Azerbeidzjan,Azerbajdzjan
-Belarus,Weißrussland,Bielorrusia,Biélorussie,Hviterussland,Bělorusko,Беларусь,Wit-Rusland,Vitryssland
+Belarus,Belarus,Bielorrusia,Biélorussie,Hviterussland,Bělorusko,Беларусь,Wit-Rusland,Vitryssland
 Belgium,Belgien,Bélgica,Belgique,Belgia,Belgie,Бельгия,België,Belgien
 Bosnia and Herzegovina,Bosnien und Herzegowina,Bosnia y Herzegovina,Bosnie-Herzégovine,Bosnia-Hercegovina,Bosna a Hercegovina,Босния и Герцеговина,Boznië en Herzegovina,Bosnien och Hercegovina
 Bulgaria,Bulgarien,Bulgaria,Bulgarie,Bulgaria,Bulharsko,Болгария,Bulgarije,Bulgarien


### PR DESCRIPTION
Update german translation of Belarus from Weißrussland to Belarus, see https://de.wikipedia.org/wiki/Belarus