### PR TITLE
Fix Norwegian Bokmål name of capital of Moldova

### DIFF
--- a/src/data/capital.csv
+++ b/src/data/capital.csv
@@ -33,7 +33,7 @@ Lithuania,Vilnius,Vilnius,Vilna,Vilnius,Vilnius,Vilnius,Вильнюс,Vilnius,V
 Luxembourg,Luxembourg City,Luxemburg,Luxemburgo,Luxembourg,Luxembourg,Lucemburk,город Люксембург,Luxemburg,Luxemburg,Luxemburgo,卢森堡市(Luxembourg City),盧森堡市 (Luxembourg City),Luksemburg,Lussemburgo,Luxembourg
 North Macedonia,Skopje,Skopje,Skopie,Skopje,Skopje,Skopje,Скопье,Skopje,Skopje,Escópia,斯科普里(Skopje),斯科普里 (Skopje),Skopje,Skopje,Skopje
 Malta,Valletta,Valletta,La Valeta,La Valette,Valletta,Valletta,Валлетта,Valletta,Valletta,Valeta,瓦莱塔(Valletta),瓦萊塔 (Valletta),Valletta,La Valletta,Valletta
-Moldova,Chișinău,Chișinău,Chisináu,Chișinău,Chisinau,Kišiněv,Кишинёв,Chișinău,Chișinău,Quixinau,基希讷乌(Chișinău),基希訥烏 (Chișinău),Kiszyniów,Chișinău,Chisinau
+Moldova,Chișinău,Chișinău,Chisináu,Chișinău,Chișinău,Kišiněv,Кишинёв,Chișinău,Chișinău,Quixinau,基希讷乌(Chișinău),基希訥烏 (Chișinău),Kiszyniów,Chișinău,Chisinau
 Monaco,Monaco,Monaco,Mónaco,Monaco,Monaco,Monaco-Ville,Монако,Monaco,Monaco,"Mônaco (BR), Mónaco (PT)",摩纳哥(Monaco),摩納哥 (Monaco),Monako,Comune di Monaco,Monaco
 Montenegro,Podgorica,Podgorica,Podgorica,Podgorica,Podgorica,Podgorica,Подгорица,Podgorica,Podgorica,Podgorica,波德戈里察(Podgorica),波德戈里察 (Podgorica),Podgorica,Podgorica,Podgorica
 Netherlands,Amsterdam,Amsterdam,Ámsterdam,Amsterdam,Amsterdam,Amsterdam,Амстердам,Amsterdam,Amsterdam,"Amsterdã (BR), Amsterdão (PT)",阿姆斯特丹(Amsterdam),阿姆斯特丹 (Amsterdam),Amsterdam,Amsterdam,Amsterdam


### PR DESCRIPTION
The official Norwegian spelling uses diacritical marks. Sources:

- https://sprakradet.no/stedsnavn-og-navn-pa-statsorgan/navnelister-norsk-skrivemate/utanlandske-stadnamn-navn-pa-stater-og-sprak-transkripsjon/utanlandske-stadnamn/#Chisinau
- https://snl.no/Chi%C5%9Fin%C4%83u