### PR TITLE
Add script for updating flags from Wikimedia

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+requests = "*"
 
 [packages]
 brain-brew = "==0.3.11"
@@ -17,3 +18,4 @@ build_experimental = "python utils/generate_and_build.py recipes/source_to_anki_
 generate_templates = "python utils/generate_and_build.py"
 zip = "python utils/zip_decks.py"
 flag_similarity = "python utils/flag_similarity.py"
+update_flags = "python utils/update_flags.py"

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ build_experimental = "python utils/generate_and_build.py recipes/source_to_anki_
 generate_templates = "python utils/generate_and_build.py"
 zip = "python utils/zip_decks.py"
 flag_similarity = "python utils/flag_similarity.py"
-update_flags = "python utils/update_flags.py"
+update_flags = "python utils/update_flags.py fetch"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b04359812ebe8f3229e4c18502fc4d2d774bb929a160c9045423aefd00f72604"
+            "sha256": "ba80dbde72e4ee4ba6717a0cb8caed1d4f807b63b428e732b1ef095c89175943"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -152,5 +152,158 @@
             "version": "==6.0.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "certifi": {
+            "hashes": [
+                "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de",
+                "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2025.10.5"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:027f6de494925c0ab2a55eab46ae5129951638a49a34d87f4c3eda90f696b4ad",
+                "sha256:077fbb858e903c73f6c9db43374fd213b0b6a778106bc7032446a8e8b5b38b93",
+                "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394",
+                "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89",
+                "sha256:0f04b14ffe5fdc8c4933862d8306109a2c51e0704acfa35d51598eb45a1e89fc",
+                "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86",
+                "sha256:194f08cbb32dc406d6e1aea671a68be0823673db2832b38405deba2fb0d88f63",
+                "sha256:1bee1e43c28aa63cb16e5c14e582580546b08e535299b8b6158a7c9c768a1f3d",
+                "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f",
+                "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8",
+                "sha256:244bfb999c71b35de57821b8ea746b24e863398194a4014e4c76adc2bbdfeff0",
+                "sha256:2677acec1a2f8ef614c6888b5b4ae4060cc184174a938ed4e8ef690e15d3e505",
+                "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161",
+                "sha256:2aaba3b0819274cc41757a1da876f810a3e4d7b6eb25699253a4effef9e8e4af",
+                "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152",
+                "sha256:2c9d3c380143a1fedbff95a312aa798578371eb29da42106a29019368a475318",
+                "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72",
+                "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4",
+                "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e",
+                "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3",
+                "sha256:44c2a8734b333e0578090c4cd6b16f275e07aa6614ca8715e6c038e865e70576",
+                "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c",
+                "sha256:4902828217069c3c5c71094537a8e623f5d097858ac6ca8252f7b4d10b7560f1",
+                "sha256:4bd5d4137d500351a30687c2d3971758aac9a19208fc110ccb9d7188fbe709e8",
+                "sha256:4fe7859a4e3e8457458e2ff592f15ccb02f3da787fcd31e0183879c3ad4692a1",
+                "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2",
+                "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44",
+                "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26",
+                "sha256:5947809c8a2417be3267efc979c47d76a079758166f7d43ef5ae8e9f92751f88",
+                "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016",
+                "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede",
+                "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf",
+                "sha256:5cb4d72eea50c8868f5288b7f7f33ed276118325c1dfd3957089f6b519e1382a",
+                "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc",
+                "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0",
+                "sha256:64b55f9dce520635f018f907ff1b0df1fdc31f2795a922fb49dd14fbcdf48c84",
+                "sha256:6515f3182dbe4ea06ced2d9e8666d97b46ef4c75e326b79bb624110f122551db",
+                "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1",
+                "sha256:6aee717dcfead04c6eb1ce3bd29ac1e22663cdea57f943c87d1eab9a025438d7",
+                "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed",
+                "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8",
+                "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133",
+                "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e",
+                "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef",
+                "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14",
+                "sha256:778d2e08eda00f4256d7f672ca9fef386071c9202f5e4607920b86d7803387f2",
+                "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0",
+                "sha256:798d75d81754988d2565bff1b97ba5a44411867c0cf32b77a7e8f8d84796b10d",
+                "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828",
+                "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f",
+                "sha256:7c308f7e26e4363d79df40ca5b2be1c6ba9f02bdbccfed5abddb7859a6ce72cf",
+                "sha256:7fa17817dc5625de8a027cb8b26d9fefa3ea28c8253929b8d6649e705d2835b6",
+                "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328",
+                "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090",
+                "sha256:837c2ce8c5a65a2035be9b3569c684358dfbf109fd3b6969630a87535495ceaa",
+                "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381",
+                "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c",
+                "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb",
+                "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc",
+                "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a",
+                "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec",
+                "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc",
+                "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac",
+                "sha256:9cd98cdc06614a2f768d2b7286d66805f94c48cde050acdbbb7db2600ab3197e",
+                "sha256:9d1bb833febdff5c8927f922386db610b49db6e0d4f4ee29601d71e7c2694313",
+                "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569",
+                "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3",
+                "sha256:a61900df84c667873b292c3de315a786dd8dac506704dea57bc957bd31e22c7d",
+                "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525",
+                "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894",
+                "sha256:a8bf8d0f749c5757af2142fe7903a9df1d2e8aa3841559b2bad34b08d0e2bcf3",
+                "sha256:a9768c477b9d7bd54bc0c86dbaebdec6f03306675526c9927c0e8a04e8f94af9",
+                "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a",
+                "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9",
+                "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14",
+                "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25",
+                "sha256:b5d84d37db046c5ca74ee7bb47dd6cbc13f80665fdde3e8040bdd3fb015ecb50",
+                "sha256:b7cf1017d601aa35e6bb650b6ad28652c9cd78ee6caff19f3c28d03e1c80acbf",
+                "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1",
+                "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3",
+                "sha256:c4ef880e27901b6cc782f1b95f82da9313c0eb95c3af699103088fa0ac3ce9ac",
+                "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e",
+                "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815",
+                "sha256:cb01158d8b88ee68f15949894ccc6712278243d95f344770fa7593fa2d94410c",
+                "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6",
+                "sha256:cc00f04ed596e9dc0da42ed17ac5e596c6ccba999ba6bd92b0e0aef2f170f2d6",
+                "sha256:cd09d08005f958f370f539f186d10aec3377d55b9eeb0d796025d4886119d76e",
+                "sha256:cd4b7ca9984e5e7985c12bc60a6f173f3c958eae74f3ef6624bb6b26e2abbae4",
+                "sha256:ce8a0633f41a967713a59c4139d29110c07e826d131a316b50ce11b1d79b4f84",
+                "sha256:cead0978fc57397645f12578bfd2d5ea9138ea0fac82b2f63f7f7c6877986a69",
+                "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15",
+                "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191",
+                "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0",
+                "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897",
+                "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd",
+                "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2",
+                "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794",
+                "sha256:e824f1492727fa856dd6eda4f7cee25f8518a12f3c4a56a74e8095695089cf6d",
+                "sha256:e912091979546adf63357d7e2ccff9b44f026c075aeaf25a52d0e95ad2281074",
+                "sha256:eaabd426fe94daf8fd157c32e571c85cb12e66692f15516a83a03264b08d06c3",
+                "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224",
+                "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838",
+                "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a",
+                "sha256:f155a433c2ec037d4e8df17d18922c3a0d9b3232a396690f17175d2946f0218d",
+                "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d",
+                "sha256:f34be2938726fc13801220747472850852fe6b1ea75869a048d6f896838c896f",
+                "sha256:f820802628d2694cb7e56db99213f930856014862f3fd943d290ea8438d07ca8",
+                "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490",
+                "sha256:f8e160feb2aed042cd657a72acc0b481212ed28b1b9a95c0cee1621b524e1966",
+                "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9",
+                "sha256:fa09f53c465e532f4d3db095e0c55b615f010ad81803d383195b6b5ca6cbf5f3",
+                "sha256:faa3a41b2b66b6e50f84ae4a68c64fcd0c44355741c6374813a800cd6695db9e",
+                "sha256:fd44c878ea55ba351104cb93cc85e74916eb8fa440ca7903e57575e97394f608"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.4.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
+                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.11"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760",
+                "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2.5.0"
+        }
+    }
 }

--- a/utils/update_flags.py
+++ b/utils/update_flags.py
@@ -20,6 +20,17 @@ git-difftool-img` with:
 compare -compose src "$1" "$2" png:- | montage -geometry 400x+2+2 "$1" "$2" png:- png:- | display -
 ```
 
+(for marking up any changed pixels)
+
+or
+
+```
+convert "$1" "$2" -fx "1 - sqrt(pow(u.r-v.r,2) + pow(u.g-v.g,2) + pow(u.b-v.b,2))" -normalize png:- | montage -geometry 400x+2+2 "$1" "$2" png:- png:- | display -
+```
+
+(for displaying the magnitude of the changes using a naive Euclidean
+RGB distance)
+
 as the `git-difftool-img` executable works well.
 
 """

--- a/utils/update_flags.py
+++ b/utils/update_flags.py
@@ -34,6 +34,7 @@ RGB distance)
 as the `git-difftool-img` executable works well.
 
 """
+import argparse
 import csv
 import tempfile
 import re
@@ -303,6 +304,20 @@ def browse_wikimedia_source():
     webbrowser.open(wikimedia_url)
     webbrowser.open(wikipedia_url)
 
+def parse_args():
+    parser = argparse.ArgumentParser()
+    subparser = parser.add_subparsers(dest='subparser_name')
+
+    parser_source = subparser.add_parser("source", help="open Wikipedia and Wikimedia for the first changed flag.")
+    parser_fetch = subparser.add_parser("fetch", help="update all flags, fetching from Wikimedia.")
+
+    # parser_fetch.add_argument("--check-pixel-diff", action="store_true", help="use imagemagick to check pixel diff and discard changes with no diff")
+
+    args = parser.parse_args()
+
+    return args
+
+
 def main():
     with tempfile.TemporaryDirectory(dir=".") as temp_dir_:
         temp_dir = Path(temp_dir_)
@@ -311,9 +326,10 @@ def main():
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
+    args = parse_args()
+    if args.subparser_name == "fetch":
         main()
-    elif (len(sys.argv) == 2) and (sys.argv[1] == "--source"):
+    elif args.subparser_name == "source":
         browse_wikimedia_source()
     else:
         raise ValueError("Unknown arguments.")

--- a/utils/update_flags.py
+++ b/utils/update_flags.py
@@ -285,10 +285,14 @@ def browse_wikimedia_source():
         check=True,
         text=True,
     )
-    first_changed_flag = [
+    changed_flags = [
         s.removeprefix("src/media/flags/") for s in result.stdout.split("\n") if
         s.startswith("src/media/flags/")
-    ][0]
+    ]
+    if len(changed_flags) == 0:
+        print("No changed flags!")
+        return
+    first_changed_flag = changed_flags[0]
 
     wikimedia_filename = list_flags_with_sources()[first_changed_flag]
 

--- a/utils/update_flags.py
+++ b/utils/update_flags.py
@@ -150,11 +150,11 @@ def update_geometry(wikimedia_fetch: Path):
     view_box_a = Attrib.extract("viewBox", svg_text, svg_start, svg_end)
 
     if (width_a is None) and (height_a is None):
-        view_box_str = re.split(" |,", view_box_a.value)
-        if not len(view_box_str) == 4:
-            raise ValueError(f"viewBox has incorrect length {len(view_box_str)}!")
+        view_box_str_l = re.split(" |,", view_box_a.value)
+        if not len(view_box_str_l) == 4:
+            raise ValueError(f"viewBox has incorrect length {len(view_box_str_l)}!")
 
-        dimensions = [float(x) for x in view_box_str[2:4]]
+        dimensions = [float(x) for x in view_box_str_l[2:4]]
         new_width = round(dimensions[0] * (250/dimensions[1]))
         new_height = 250
 
@@ -309,7 +309,7 @@ def update_flag(
     if replace_current_version:
         move_svg_to_media_dir(wikimedia_fetch)
 
-def list_flags_with_sources() -> list[tuple[str, str]]:
+def list_flags_with_sources() -> dict[str, str]:
     """Create a tuple of local and wikimedia filenames of flags."""
 
     flags = {}

--- a/utils/update_flags.py
+++ b/utils/update_flags.py
@@ -36,10 +36,11 @@ as the `git-difftool-img` executable works well.
 """
 import argparse
 import csv
-import tempfile
+import os
 import re
 import shutil
 import subprocess
+import tempfile
 import webbrowser
 
 from dataclasses import dataclass
@@ -227,7 +228,8 @@ def run_svgo(wikimedia_fetch) -> Path:
     subprocess.run(["svgo", "-i", str(wikimedia_fetch), "-o", str(svgo_attempt)])
 
     if svgo_attempt.stat().st_size < wikimedia_fetch.stat().st_size:
-        return svgo_attempt.move(wikimedia_fetch)
+        #svgo_attempt.move(wikimedia_fetch)
+        os.replace(svgo_attempt, wikimedia_fetch)
 
     return wikimedia_fetch
 

--- a/utils/update_flags.py
+++ b/utils/update_flags.py
@@ -1,0 +1,260 @@
+"""Check flags on Wikimedia for updates.
+
+For each flag:
+
+1. Fetch the latest flag from Wikimedia (based on `sources.csv`).
+2. Adjust the width/height/viewBox as described in CONTRIBUTING.md
+3. Run `svgo`.  (We assume that it's installed; if not we crash.)
+4. Overwrite the current file in `src/media/flags/`.
+
+Comparing the files is currently left to the user.  The idea is that
+they can compare the current and the updated versions with `git diff`
+using whatever tool they prefer.
+
+Given the text nature of SVG and the fact that many of the files are
+small, a naive text diff is itself quite useful, especially with word
+diff (`git diff --word-diff`).  For an image diff, `git difftool -x
+git-difftool-img` with:
+
+```
+compare -compose src "$1" "$2" png:- | montage -geometry 400x+2+2 "$1" "$2" png:- png:- | display -
+```
+
+as the `git-difftool-img` executable works well.
+
+"""
+import csv
+import tempfile
+import re
+import shutil
+import subprocess
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+def fetch_flag_from_wikimedia(
+    local_filename: str,
+    wikimedia_filename: str,
+    temp_dir: Path,
+) -> Path:
+    """Fetch flag from Wikimedia."""
+    fetch_link = "https://commons.wikimedia.org/wiki/Special:FilePath/File:" + wikimedia_filename
+
+    headers = {"user-agent": "aug-flag-update/0.0.0"}
+    r = requests.get(
+        fetch_link,
+        headers=headers,
+    )
+
+    wikimedia_fetch = temp_dir / local_filename
+
+    with open(wikimedia_fetch, "wb") as f:
+        f.write(r.content)
+
+    return wikimedia_fetch
+
+@dataclass
+class Attrib:
+    """SVG attributes.
+
+    Helps obtain, store and process the values of various attributes
+    (height, width, viewBox) within the root `<svg>` tag.  Acts as a
+    very partial XML parser.  (Unfortunately, the clean solution of
+    just using an XML parser lead to minor, non-semantic (mainly (but
+    not solely) whitespace) changes throughout the document.  On a
+    casual overview, SVGO (slightly surprisingly) did not seem to
+    entirely normalise the changes, hence leading to some spurious
+    diffs.  The alternative solution of just extracting and properly
+    XML-parsing the root `<svg>` tag did not work, as some XML
+    namespace declarations (not used within the `<svg>` tag, but used
+    elsewhere in the document) where removed.  Hence, this more ugly
+    but more surgical approach of only directly modifying the target
+    attributes of the `<svg>` was taken.
+
+    """
+    name: str
+    value: str
+    num: float | None = None
+
+    @classmethod
+    def extract(
+        cls,
+        attrib_name: str,
+        text: str,
+        start: int,
+        end: int,
+        obtain_num: bool = False,
+    ):
+        """Extract given attribute from sub-set of supplied text.
+
+        start and end should delimit the range of the `<svg>` tag
+        (i.e. the subset of the entire text from which we want to
+        extract the attribute values).
+
+        """
+        regexp = re.compile(attrib_name + r'="([^"]*)"')
+        m = regexp.search(text, start, end)
+        if m is None:
+            return None
+        if obtain_num:
+            return Attrib(attrib_name, m.group(1), float(m.group(1).removesuffix("px")))
+        return Attrib(attrib_name, m.group(1))
+
+    def replace(self, text: str, new_value: int):
+        """Replace given attribute values.
+
+        Assumes that the first occurrence of `attrib="value"` is the
+        desired one.  (This should be generally correct, since it's
+        highly unlikely there would be any such occurrences before the
+        root SVG tag, though technically, they could occur in, say, a
+        comment.)
+
+        """
+        regexp = re.compile(rf'{self.name}="({re.escape(self.value)})"')
+        replacement = rf'{self.name}="{new_value}"'
+        return re.sub(regexp, replacement, text, count=1)
+
+def update_geometry(wikimedia_fetch: Path):
+    """Update the SVG to have a height of 250.
+
+    Change width proportionally.  Add viewBox if such did not exist.
+
+    """
+    with open(wikimedia_fetch) as f:
+        svg_text = f.read()
+
+    svg_start = svg_text.find("<svg")
+    svg_end = svg_text.find(">", svg_start)
+
+    width_a = Attrib.extract("width", svg_text, svg_start, svg_end, obtain_num=True)
+    height_a = Attrib.extract("height", svg_text, svg_start, svg_end, obtain_num=True)
+    view_box_a = Attrib.extract("viewBox", svg_text, svg_start, svg_end)
+
+    if (width_a is None) and (height_a is None):
+        view_box_str = re.split(" |,", view_box_a.value)
+        if not len(view_box_str) == 4:
+            raise ValueError(f"viewBox has incorrect length {len(view_box_str)}!")
+
+        dimensions = [float(x) for x in view_box_str[2:4]]
+        new_width = round(dimensions[0] * (250/dimensions[1]))
+        new_height = 250
+
+        svg_text = (svg_text[0:svg_end] +
+                    f' width="{new_width}" height="{new_height}"' +
+                    svg_text[svg_end:])
+    elif (width_a is None) and (height_a is None):
+        raise ValueError("Expected either both or none of width and height to be missing!")
+    else:
+        if view_box_a is None:
+            view_box_str = f"0 0 {width_a.num} {height_a.num}"
+            svg_text = svg_text[0:svg_end] + f' viewBox="{view_box_str}"' + svg_text[svg_end:]
+
+        new_width = round(width_a.num * (250/height_a.num))
+        new_height = 250
+
+        svg_text = width_a.replace(svg_text, new_width)
+        svg_text = height_a.replace(svg_text, new_height)
+
+    with open(wikimedia_fetch, "w") as f:
+        f.write(svg_text)
+
+## This unfortunately leads to changes elsewhere (other than in the
+## root svg element) in the file, so I've switched to the above more
+## ugly regexp solution.
+# def update_geometry_with_xml(wikimedia_fetch: Path) -> None:
+#     t = ET.parse(wikimedia_fetch)
+#     root = t.getroot()
+#     root.attrib
+
+#     if "height" in root.attrib:
+#         initial_height_str = root.attrib["height"]
+#     else:
+#         raise ValueError("Missing height!")
+
+#     if "width" in root.attrib:
+#         initial_width_str = root.attrib["width"]
+#     else:
+#         raise ValueError("Missing width!")
+    
+#     if not "viewBox" in root.attrib:
+#         root.attrib["viewBox"] = f"0 0 {initial_width_str} {initial_height_str}"
+
+#     initial_height = float(initial_height_str.removesuffix("px"))
+#     initial_width = float(initial_width_str.removesuffix("px"))
+
+#     width = initial_width * (250/initial_height)
+
+#     root.attrib["height"] = str(250)
+#     root.attrib["width"] = str(width)
+
+#     ET.register_namespace("", "http://www.w3.org/2000/svg")
+#     t.write(
+#         wikimedia_fetch,
+#         xml_declaration=True,
+#         encoding="utf-8",
+#         default_namespace="",
+#     )
+
+def run_svgo(wikimedia_fetch) -> None:
+    """Run svgo.
+
+    Currently, doesn't handle svgo errors, at all, but they should be
+    visible in the terminal.
+
+    """
+    subprocess.run(["svgo", str(wikimedia_fetch)])
+
+def move_svg_to_media_dir(wikimedia_fetch: Path) -> None:
+    """Move the generated SVG to src/media/flags/"""
+    target_dir = Path(".") / "src" / "media" / "flags"
+    target_file = target_dir / wikimedia_fetch.name
+    shutil.move(wikimedia_fetch, target_file)
+
+def update_flag(
+    local_filename: str,
+    wikimedia_filename: str,
+    temp_dir: Path,
+) -> None:
+    """"""
+    wikimedia_fetch = fetch_flag_from_wikimedia(
+        local_filename,
+        wikimedia_filename,
+        temp_dir,
+    )
+    update_geometry(wikimedia_fetch)
+    run_svgo(wikimedia_fetch)
+    move_svg_to_media_dir(wikimedia_fetch)
+
+def list_flags_with_sources() -> list[tuple[str, str]]:
+    """Create a tuple of local and wikimedia filenames of flags."""
+
+    flags = []
+
+    with open("sources.csv") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            mediatype = row["File"].split("-")[1]
+            is_blurred = (row["File"].split("-")[-1] == "blur.svg")
+            if (mediatype == "flag") and (not is_blurred):
+                local_filename = row["File"]
+                # country = aug_map_country_dict[filename]
+                wikimedia_source = row["Source"]
+                WIKIMEDIA_DESCRIPTION_PAGE_PREFIX = "https://commons.wikimedia.org/wiki/File:"
+                if not wikimedia_source.startswith(WIKIMEDIA_DESCRIPTION_PAGE_PREFIX):
+                    raise ValueError(f"Non-wikimedia source: {wikimedia_source}!")
+                wikimedia_filename = wikimedia_source.removeprefix(WIKIMEDIA_DESCRIPTION_PAGE_PREFIX)
+
+                flags.append((local_filename, wikimedia_filename))
+
+    return flags
+
+def main():
+    with tempfile.TemporaryDirectory(dir=".") as temp_dir_:
+        temp_dir = Path(temp_dir_)
+        for local_filename, wikimedia_filename in list_flags_with_sources():
+            update_flag(local_filename, wikimedia_filename, temp_dir)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It's rudimentary and doesn't do anything beyond updating the flags — it doesn't carry out any actual comparisons and it doesn't prepare a log of changes from the Wikimedia page.  IMO the former (comparison) wouldn't actually be useful, since the user can easily use whatever tool they prefer, but the latter (either preparing a digest or maybe just opening the relevant Wikimedia description page in a browser), might.  OTOH I'm not sure what's the best way to do the latter, especially when there are many changed flags, so I'm leaving this for now.

The script might end up needing tweaks once I go through the ton of flags apparently needing updates, in case there are any ways to avoid false positives.  Some are not easily unavoidable, likely caused by changes to svgo (e.g. the flag of Abkhazia now has the semantically-equivalent `27.97 114` instead of `27.97L114` in one place, almost certainly due to svgo (the current version on Wikimedia has `L`, there, so it's not due to tweaks on Wikimedia)).

As discussed in the linked issue, it might turn out necessary to pin the svgo version (installing it with npm/yarn etc.), but this won't help much for the now since different svgo versions might have been used for different files, in the past.  (I'm also hesitant adding another package manager to our repo, (contributors having to install both python/pipenv and nodejs) though if it's only for this one use-case _maybe_ it's not a major problem.)  OTOH if we don't resolve this now (switching to a single svgo version) it'll continue to annoy us in the future, especially if we want an automated/semi-automated workflow.  OTOTOH I think we're currently in the exploratory phase (whether the script is actually useful at all), so overcomplicating is probably unwise.

Fix #706.

<hr/>

Edit: Running the script in full, now that its design has been finalised (especially regarding rounding of widths) — I didn't want to hammer Wikimedia unnecessarily — it appears that there are 210 flags to update :scream:, and looking at the first several it appears that most are legit (at least to the extent that upstream (Wikimedia) has indeed changed (in one case (Australia) I have doubts about the soundness of the changes)); one (Abkhazia) is due to `svgo` and one (Argentina) is due to previous minor conversion issues.